### PR TITLE
docs: add persistent agent and architecture context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,146 @@
+# Agent Instructions
+
+This file applies repository-wide. Nested, more specific instructions (e.g. per-directory
+`AGENTS.md` files added later) take precedence over this top-level file.
+
+## Repository overview
+
+| Layer       | Tech                                             |
+| ----------- | ------------------------------------------------ |
+| Client      | React (Vite), TypeScript, Redux Toolkit, Tailwind |
+| Backend     | Express, TypeScript, MongoDB (Mongoose), Passport |
+| Infra       | Kubernetes manifests (legacy, reference only), Docker Compose |
+| CI/CD       | GitHub Actions                                   |
+
+## Repository map
+
+```
+kitapKurdu/
+├── client/                  # React/Vite frontend
+│   ├── src/main.tsx         # Entry point
+│   ├── src/pages/           # Route-level components
+│   ├── src/components/      # Shared UI components
+│   ├── src/redux/           # Redux store, slices, API helper
+│   └── vite.config.ts       # Vite config (port 3000, /api proxy)
+├── backend/                 # Express API
+│   ├── index.ts             # Entry point (env checks, MongoDB connect)
+│   ├── app.ts               # Express app (routes, CORS, healthz, sitemap, OG)
+│   ├── routes/api/          # Route handlers (/api/books, /api/user, etc.)
+│   ├── controllers/         # Request handlers
+│   ├── services/            # Business logic
+│   ├── models/              # Mongoose models (Books, User, etc.)
+│   ├── middleware/           # Auth, error handler, validation
+│   ├── src/config/passport.ts  # Passport (local, Google, JWT)
+│   ├── metrics.ts           # Prometheus /metrics endpoint
+│   └── test/setup.ts        # Jest setup (mongodb-memory-server)
+├── infra/                   # Kubernetes manifests
+│   ├── k8s/                 # Production manifests
+│   ├── k8s-dev/             # Dev manifests
+│   ├── k8s-staging/         # Staging manifests
+│   └── secrets/             # Sealed secrets
+├── .github/workflows/       # CI/CD pipelines
+├── package.json             # Root npm scripts
+└── docker-compose.yaml
+```
+
+## Verified commands
+
+Only run commands that exist in the actual `package.json` scripts. Do not invent or
+guess commands.
+
+### Root
+
+| Command              | Script                                    |
+| -------------------- | ----------------------------------------- |
+| `npm run local`      | Starts frontend + backend via Forego |
+| `npm run local:frontend` | `npm --prefix ./client start`        |
+| `npm run local:backend`  | `PORT=5000 npm --prefix ./backend run dev` |
+| `npm test`           | Placeholder (`echo "Error: no test specified" && exit 1`) — **do not use for verification.** |
+
+### Client (`client/`)
+
+| Command              | Script                                |
+| -------------------- | ------------------------------------- |
+| `npm start`          | `vite` (dev server, port 3000)        |
+| `npm run build`      | `tsc && vite build`                   |
+| `npm run preview`    | `vite preview`                        |
+
+### Backend (`backend/`)
+
+| Command              | Script                                         |
+| -------------------- | -----------------------------------------------|
+| `npm run dev`        | `ts-node-dev ... index.ts` (watch mode)       |
+| `npm run build`      | `npm install && tsc -p tsconfig.build.json`    |
+| `npm test`           | `jest --no-cache`                              |
+| `npm run test:ci`    | `jest`                                         |
+| `npm start`          | `node ./dist/index.js` (requires `npm run build` first) |
+
+### Install dependencies
+
+When lockfiles have not changed, install with `npm ci` separately in `./`, `./client`,
+and `./backend` as needed.
+
+## Local runtime
+
+| Service  | Port |
+| -------- | ---- |
+| Client   | 3000 |
+| Backend  | 5000 |
+
+The Vite dev server proxies `/api` requests to `http://localhost:5000`.
+
+## Agent workflow
+
+1. **One issue per branch.** Create a dedicated branch from `main`.
+2. **Bounded changes.** Only modify files and directories that the issue scope
+   authorises. Do not refactor unrelated code, update dependencies, or reformat
+   files outside scope.
+3. **Do not commit directly to main.** Always work on a feature branch.
+4. **Link the PR** with `Closes #<number>` in the PR description.
+5. **Report verification.** After changes, run the closest applicable checks and
+   report the command and outcome. For documentation-only changes, builds are
+   not required; validating markdown and relative links is sufficient.
+6. **Never merge, push, deploy, or open a PR unless explicitly requested.**
+   Only the operator triggers these actions.
+7. **Do not deploy to or alter Kubernetes infrastructure.** Kubernetes manifests
+   in `infra/` are legacy artifacts retained for reference. Do not deploy to,
+   re-enable, or reactivate them unless an issue explicitly requests it.
+   The canonical deployment targets are Vercel (frontend) and Render (backend).
+
+## Security boundaries
+
+- **Never read, display, or commit actual secret values.** Refer to environment
+  variable **names only**.
+- **Never alter `.env` files**, secret manifests (`infra/secrets/`), CI/CD
+  workflow definitions, deployment manifests, dependency files
+  (`package.json`, lockfiles), or generated code (`dist/`, `build/`,
+  `node_modules/`) unless the issue scope **explicitly** requires it.
+- **Never weaken or skip tests.** Keep existing test assertions intact and
+  passing.
+- **Client `VITE_*` variables are public at build time.** They are embedded in
+  JavaScript bundles and must never contain private credentials.
+
+## Testing guidance (current state)
+
+| Area      | Status                                                        |
+| --------- | ------------------------------------------------------------- |
+| Backend   | Jest + Supertest + mongodb-memory-server. Route tests under `backend/routes/api/__test__/`. Run with `npm test` or `npm run test:ci` in `backend/`. |
+| Client    | No working unit-test script. `@testing-library/*` packages are installed but the test infrastructure is incomplete. |
+| Playwright | Config exists (`client/playwright.config.ts`). First smoke tests are tracked in a separate issue (#316). |
+
+When verifying changes, run the **closest relevant check** for the layer you
+touched. For documentation-only edits, a build is not necessary.
+
+CI tests must use isolated test infrastructure (e.g., in-memory MongoDB via
+mongodb-memory-server) and must never target production services. Preview and
+E2E tests may use a dedicated test/staging backend if one is provisioned in the
+future, but must not mutate production data.
+
+## Definition of done
+
+- [ ] The issue's acceptance criteria are met.
+- [ ] The diff is minimal (no unrelated changes).
+- [ ] Applicable tests/checks pass (or documentation validity confirmed).
+- [ ] Documentation is updated if the PR changes architecture, APIs, or workflows.
+- [ ] No secret values are present in the diff.
+- [ ] The PR description includes a summary, risks (if any), and follow-up items.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
   <a href="#rocket-technologies">Technologies</a> &#xa0; | &#xa0;
   <a href="#white_check_mark-requirements">Requirements</a> &#xa0; | &#xa0;
   <a href="#checkered_flag-starting">Starting</a> &#xa0; | &#xa0;
+  <a href="#books-documentation">Documentation</a> &#xa0; | &#xa0;
   <a href="#memo-license">License</a> &#xa0; | &#xa0;
   <a href="https://github.com/sayinmehmet47" target="_blank">Author</a>
 </p>
@@ -125,6 +126,11 @@ $ cd ..
 
 
 
+
+## :books: Documentation
+
+- [Agent instructions](AGENTS.md) — commands, workflow, security, and testing guidance for contributors and automation.
+- [Architecture](docs/architecture.md) — current repository architecture, data flow, API routes, environment variables, deployment topology, and test state.
 
 ## :memo: License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,175 @@
+# Repository Architecture
+
+This document describes the **current** architecture of the kitapKurdu repository,
+not an aspirational design. It is kept in sync with the actual source tree.
+
+## High-level request flow
+
+```
+Browser React app  ──>  Vite proxy /api  ──>  Express server  ──>  MongoDB
+                             (dev only)         (port 5000)        external services
+```
+
+- In local development the [Vite dev server](../client/vite.config.ts) proxies
+  `/api` requests to `http://localhost:5000`.
+- In production the client is deployed separately and communicates with the
+  backend over HTTPS (CORS origins are configured in
+  [`backend/app.ts`](../backend/app.ts)).
+
+## Repository structure & entry points
+
+| Path                          | Role                                          |
+| ----------------------------- | --------------------------------------------- |
+| [`client/src/main.tsx`](../client/src/main.tsx)   | React application entry point           |
+| [`client/src/redux/store.ts`](../client/src/redux/store.ts) | Redux store configuration       |
+| [`backend/index.ts`](../backend/index.ts)          | Backend entry point — env checks, MongoDB connect, cron, server start |
+| [`backend/app.ts`](../backend/app.ts)              | Express app — CORS, Passport, routes, `/healthz`, `/sitemap.xml`, `/og/book/:id` |
+| [`backend/routes/index.ts`](../backend/routes/index.ts) | API route aggregator mounted at `/api`   |
+| [`backend/controllers/`](../backend/controllers/)   | Request handlers                               |
+| [`backend/services/`](../backend/services/)        | Business logic                                 |
+| [`backend/models/`](../backend/models/)            | Mongoose schemas (`Books`, `User`, `Messages`, `Rating`, `SearchAnalytics`) |
+| [`backend/middleware/`](../backend/middleware/)     | Auth (JWT, admin), error handler, validation    |
+| [`backend/metrics.ts`](../backend/metrics.ts)      | Prometheus `/metrics` endpoint                 |
+| [`backend/cronJob.ts`](../backend/cronJob.ts)      | Scheduled tasks (daily category update)         |
+| [`infra/k8s/`](../infra/k8s/)                      | Kubernetes manifests — production (legacy, reference only) |
+| [`infra/k8s-dev/`](../infra/k8s-dev/)              | Kubernetes manifests — dev (legacy, reference only) |
+| [`infra/k8s-staging/`](../infra/k8s-staging/)      | Kubernetes manifests — staging (legacy, reference only) |
+| [`infra/secrets/`](../infra/secrets/)              | Sealed secrets (legacy)                         |
+| [`.github/workflows/`](../.github/workflows/)      | PR checks and deployment automation (current and legacy) |
+
+## Runtime stack & local ports
+
+| Layer        | Technology                                 | Local port |
+| ------------ | ------------------------------------------ | ---------- |
+| Client       | React 18, Vite 6, TypeScript, Redux Toolkit, Tailwind CSS | 3000 |
+| Backend      | Node.js, Express 4, TypeScript             | 5000        |
+| Database     | MongoDB (Mongoose ODM)                     | —           |
+| Auth         | Passport (JWT, local, Google OAuth 2.0)    | —           |
+| Monitoring   | Prometheus, Winston logger                 | —           |
+| Scheduling   | node-cron                                   | —           |
+
+## Backend API route groups
+
+All API routes are mounted under `/api` (see [`backend/routes/index.ts`](../backend/routes/index.ts)):
+
+| Route prefix     | Purpose                  | Source                                              |
+| ---------------- | ------------------------ | --------------------------------------------------- |
+| `/api/books`     | Books CRUD, search       | [`backend/routes/api/books.ts`](../backend/routes/api/books.ts) |
+| `/api/user`      | Auth, profile, tokens    | [`backend/routes/api/user.ts`](../backend/routes/api/user.ts)   |
+| `/api/messages`  | Comments/messages        | [`backend/routes/api/messages.ts`](../backend/routes/api/messages.ts) |
+| `/api/ratings`   | Book ratings             | [`backend/routes/api/ratings.ts`](../backend/routes/api/ratings.ts) |
+| `/api/subscription` | Push notifications     | [`backend/routes/api/subscription.ts`](../backend/routes/api/subscription.ts) |
+| `/api/analytics` | Usage analytics (admin)  | [`backend/routes/api/analytics.ts`](../backend/routes/api/analytics.ts) |
+
+Non-API endpoints defined in [`backend/app.ts`](../backend/app.ts):
+
+| Path              | Purpose                         |
+| ----------------- | ------------------------------- |
+| `/healthz`        | Health check (JSON with uptime) |
+| `/metrics`        | Prometheus metrics endpoint     |
+| `/sitemap.xml`    | Dynamic sitemap for SEO         |
+| `/og/book/:id`    | Server-rendered Open Graph meta for social link previews |
+
+## Authentication overview
+
+Authentication uses Passport with three strategies (no session, fully stateless JWT):
+
+- **Local** — username/email + password with bcrypt verification.
+- **Google OAuth 2.0** — social login via Google.
+- **JWT** — short-lived access tokens and long-lived refresh tokens managed via
+  HTTP-only cookies or `Authorization: Bearer` header. Refresh tokens can also
+  travel in a query parameter for cross-domain scenarios.
+
+Source: [`backend/src/config/passport.ts`](../backend/src/config/passport.ts) and
+[`backend/middleware/auth.ts`](../backend/middleware/auth.ts).
+
+## Environment variables
+
+Only variable **names** are listed; actual values are managed through
+environment-specific mechanisms (`.env` for local, Kubernetes sealed secrets
+for clusters, platform dashboards for Vercel/Render).
+
+### Backend (`backend/.env.example` + `checkvariables.ts`)
+
+Required at startup:
+
+- `MONGO_URI`
+- `JWT_SECRET`
+- `REFRESH_TOKEN_SECRET_KEY`
+- `ACCESS_TOKEN_SECRET_KEY`
+- `PORT`
+- `GOOGLE_CLIENT_ID`
+- `GOOGLE_CLIENT_SECRET`
+- `CLIENT_URL`
+
+Also referenced at runtime:
+
+- `GOOGLE_CALLBACK_URL`
+- `SERVER_URL`
+- `NODE_ENV`
+
+### Client (`client/.env.example`)
+
+- `VITE_LOCAL_API`
+- `VITE_DEV_API`
+- `VITE_PROD_API`
+- `VITE_CLOUDINARY_URL`
+- `VITE_PUBLIC_EMAILJS_SERVICE_ID`
+- `VITE_PUBLIC_EMAILJS_TEMPLATE_ID`
+- `VITE_PUBLIC_EMAILJS_PUBLIC_KEY`
+
+**Important:** `VITE_*` variables are embedded in the JavaScript bundle at build
+time and are publicly visible in the browser. They must never contain private
+credentials or secrets.
+
+## Deployment topology
+
+### Active deployment targets
+
+| Layer    | Platform | Notes |
+| -------- | -------- | ----- |
+| Client   | **Vercel** | The client application (`client/vercel.json`) rewrites `/api` requests to the Render backend. |
+| Backend  | **Render** | The backend API is served from `https://kitapkurdu.onrender.com`. |
+
+These are the canonical deployment targets. All production traffic flows through
+this topology.
+
+### Legacy Kubernetes manifests (reference only)
+
+Kubernetes manifests are retained for historical reference and are **not**
+currently used for deployment:
+
+- [`infra/k8s/`](../infra/k8s/) — Production deployment manifests (legacy)
+- [`infra/k8s-dev/`](../infra/k8s-dev/) — Dev environment manifests (legacy)
+- [`infra/k8s-staging/`](../infra/k8s-staging/) — Staging environment manifests (legacy)
+- [`infra/secrets/`](../infra/secrets/) — Sealed secrets (legacy)
+
+These manifests are **not actively deployed**. Agents must not deploy to,
+re-enable, or reactivate Kubernetes infrastructure unless an issue
+explicitly requests it.
+
+### CI/CD
+
+GitHub Actions workflows (`.github/workflows/`) run pull-request checks and
+backend tests via [`main.yml`](../.github/workflows/main.yml). Additional legacy
+Kubernetes deployment workflow files remain present in the repository and may
+still have triggers configured. These legacy workflows are not the canonical
+deployment path and must not be invoked, repaired, or reactivated without an
+explicit issue. Migration and cleanup of deployment automation is tracked in
+issue [#317](/sayinmehmet47/kitapKurdu/issues/317).
+
+The active deployment targets are Vercel (frontend) and Render (backend),
+as described in [Deployment topology](#deployment-topology). CI unit and
+integration tests use isolated infrastructure (e.g., GitHub-hosted runners,
+in-memory MongoDB) and must not target production services. Preview and
+E2E tests may use Vercel preview deployments and may target a dedicated
+test/staging backend if one is provisioned in the future, but must never
+mutate production data.
+
+## Current test state
+
+| Area       | Status                                                                                                   |
+| ---------- | -------------------------------------------------------------------------------------------------------- |
+| Backend    | Jest + Supertest + mongodb-memory-server. Route integration tests live under [`backend/routes/api/__test__/`](../backend/routes/api/__test__/). Run with `npm test` or `npm run test:ci` in `backend/`. |
+| Client     | `@testing-library/*` packages are installed but no working unit-test script is wired up.                 |
+| Playwright | Configuration exists at [`client/playwright.config.ts`](../client/playwright.config.ts). First smoke tests are tracked in issue [#316](/sayinmehmet47/kitapKurdu/issues/316). E2E tests are not yet part of CI. |


### PR DESCRIPTION
## Summary

- add repository-wide guidance for OpenCode and future coding agents
- document the current React/Express architecture and verified commands
- record Vercel and Render as active deployment targets and Kubernetes as legacy reference infrastructure
- link the new documentation from the root README

## Verification

- `git diff --check`
- validated all newly added local Markdown links
- documentation-only change; builds and automated tests were not required

## Risks

Low. Documentation-only change with no runtime impact.

## Follow-ups

- deployment automation cleanup remains tracked in #317

Closes #312