### PR TITLE
docs: add structured GitHub contribution templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -1,0 +1,111 @@
+name: Bug Report
+description: Report a defect or unexpected behavior
+title: "bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: >
+        **Security notice**: Never paste passwords, tokens, API keys,
+        connection strings, cookies, private user data, or other secrets.
+        Use environment-variable names only (e.g. `MONGO_URI`,
+        `JWT_SECRET`).  For sensitive security issues, see the
+        [security boundaries](https://github.com/sayinmehmet47/kitapKurdu/blob/main/AGENTS.md#security-boundaries)
+        documented in AGENTS.md.
+
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      description: One-line description of the bug
+      placeholder: e.g. "Book search returns 500 when query includes special characters"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: affected_area
+    attributes:
+      label: Affected Area
+      description: Which part of the system is affected?
+      options:
+        - Frontend (client/)
+        - Backend (backend/)
+        - CI/CD (.github/workflows/)
+        - Infrastructure (infra/)
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction_steps
+    attributes:
+      label: Steps to Reproduce
+      description: Ordered steps to reproduce the behavior
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. Scroll down to '...'
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected Behavior
+      description: What should have happened?
+      placeholder: Describe the expected outcome
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual_behavior
+    attributes:
+      label: Actual Behavior
+      description: What actually happened?
+      placeholder: Describe what went wrong, including error messages
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Browser, OS, device, and relevant versions
+      placeholder: e.g. "Chrome 125, macOS 14.5, Node 20"
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs_screenshots
+    attributes:
+      label: Logs / Screenshots (optional)
+      description: Paste relevant logs or attach screenshots. Strip secrets.
+      placeholder: Log output or screenshot links
+    validations:
+      required: false
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: How severe is this bug?
+      options:
+        - Critical (blocks all work, data loss)
+        - High (major feature broken, no workaround)
+        - Medium (partial functionality broken, workaround exists)
+        - Low (cosmetic or minor inconvenience)
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmations
+      options:
+        - label: I searched existing issues and this is not a duplicate
+          required: true
+        - label: I removed all secret values, tokens, passwords, and sensitive data
+          required: true

--- a/.github/ISSUE_TEMPLATE/02_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/02_feature_request.yml
@@ -1,0 +1,97 @@
+name: Feature Request
+description: Propose a new feature or enhancement
+title: "feat: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: >
+        **Security notice**: Never paste passwords, tokens, API keys,
+        connection strings, cookies, private user data, or other secrets.
+        Use environment-variable names only (e.g. `MONGO_URI`,
+        `JWT_SECRET`).  For sensitive security issues, see the
+        [security boundaries](https://github.com/sayinmehmet47/kitapKurdu/blob/main/AGENTS.md#security-boundaries)
+        documented in AGENTS.md.
+
+  - type: textarea
+    id: problem_statement
+    attributes:
+      label: Problem Statement
+      description: What problem does this feature solve? Why is it needed?
+      placeholder: Describe the pain point or user need
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_outcome
+    attributes:
+      label: Proposed Outcome
+      description: What should the feature do? Describe the desired behavior.
+      placeholder: Describe what success looks like
+    validations:
+      required: true
+
+  - type: dropdown
+    id: affected_area
+    attributes:
+      label: Affected Area
+      description: Which part of the system will this feature touch?
+      options:
+        - Frontend (client/)
+        - Backend (backend/)
+        - CI/CD (.github/workflows/)
+        - Infrastructure / deployment
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance Criteria
+      description: Measurable, testable conditions that must be met
+      placeholder: |
+        - [ ] User can ...
+        - [ ] When ... then ...
+        - [ ] Edge case ... is handled
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered (optional)
+      description: What alternative approaches did you evaluate?
+      placeholder: Other ways to solve this problem
+    validations:
+      required: false
+
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of Scope (optional)
+      description: What should this feature explicitly NOT include?
+      placeholder: Things this feature should not address
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context (optional)
+      description: Screenshots, references, research, or related issues
+      placeholder: Links, screenshots, or notes
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmations
+      options:
+        - label: I searched existing issues and this request is not already tracked
+          required: true
+        - label: I did not include secret values, tokens, passwords, or sensitive data
+          required: true

--- a/.github/ISSUE_TEMPLATE/03_agent_task.yml
+++ b/.github/ISSUE_TEMPLATE/03_agent_task.yml
@@ -1,0 +1,94 @@
+name: Agent Task
+description: Define a bounded task for an automated coding agent
+title: "agent: "
+labels:
+  - agent-ready
+body:
+  - type: markdown
+    attributes:
+      value: >
+        **Before filling this form**, read the repository's agent instructions
+        at [AGENTS.md](https://github.com/sayinmehmet47/kitapKurdu/blob/main/AGENTS.md)
+        and the architecture overview in
+        [AGENTS.md#repository-overview](https://github.com/sayinmehmet47/kitapKurdu/blob/main/AGENTS.md#repository-overview).
+
+  - type: textarea
+    id: goal_background
+    attributes:
+      label: Goal / Background
+      description: What should be accomplished and why?
+      placeholder: Describe the objective and any necessary context
+    validations:
+      required: true
+
+  - type: textarea
+    id: in_scope
+    attributes:
+      label: In-Scope Paths or Components
+      description: Exact files, directories, or components the agent may modify
+      placeholder: |
+        - client/src/pages/Search.tsx
+        - backend/routes/api/books.ts
+        - backend/services/bookSearch.ts
+    validations:
+      required: true
+
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out-of-Scope Boundaries
+      description: What the agent must NOT touch
+      placeholder: |
+        - No changes to CI/CD workflows
+        - No dependency upgrades
+        - No reformatting outside scope
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance Criteria
+      description: Measurable, testable conditions for completion
+      placeholder: |
+        - [ ] When ... the system ...
+        - [ ] Test at backend/routes/api/__test__/... passes
+        - [ ] User can see ... on the page
+    validations:
+      required: true
+
+  - type: textarea
+    id: verification_expectations
+    attributes:
+      label: Verification Expectations
+      description: Commands or checks the agent should run before reporting done
+      placeholder: |
+        - Run `npm test` in backend/
+        - Confirm the page renders in dev mode
+    validations:
+      required: true
+
+  - type: textarea
+    id: dependencies_blockers
+    attributes:
+      label: Dependencies / Blockers (optional)
+      description: Issues, PRs, or decisions this task depends on
+      placeholder: "Blocked by #42, requires PR #77 to land first"
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: readiness_confirmations
+    attributes:
+      label: Readiness Confirmations
+      options:
+        - label: This task is bounded to one issue (single concern)
+          required: true
+        - label: Acceptance criteria are measurable and verifiable
+          required: true
+        - label: Tests or manual checks have been identified for verification
+          required: true
+        - label: No secret values, passwords, tokens, or credentials are included
+          required: true
+        - label: This task does not require deployment or Kubernetes activation (unless explicitly scoped above)
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,39 @@
+## Linked Issue
+
+Closes #
+
+## Summary
+
+<!-- Brief description of the change and why it was made -->
+
+## Scope
+
+<!-- Which files, directories, or layers were changed? -->
+
+## Risks
+
+<!-- Breaking changes, regressions, migrations, or other hazards. Write "None" if not applicable. -->
+
+## Verification / Test Evidence
+
+<!-- Commands run and their outcomes, or manual test results. Example: `npm test` in backend/ passed. -->
+
+## Screenshots / Deployment Notes
+
+<!-- If the change has no visual component or no deployment impact, write "Not applicable." -->
+
+## Follow-ups
+
+<!-- Known debt, future work, or deferred items -->
+
+---
+
+### Checklist
+
+- [ ] Acceptance criteria are met
+- [ ] Diff is minimal (no unrelated changes)
+- [ ] Applicable tests or checks pass (or documentation validity confirmed)
+- [ ] Documentation is updated where the PR changes architecture, APIs, or workflows
+- [ ] No secret values are present in the diff
+- [ ] No tests were weakened or skipped
+- [ ] No deployment or Kubernetes activation unless explicitly scoped in the issue


### PR DESCRIPTION
## Summary
- add structured forms for bug reports, feature requests, and agent-ready tasks
- add a pull request template aligned with the repository definition of done
- require bounded scope, acceptance criteria, verification evidence, and security confirmations
- disable unstructured blank issues for non-maintainers

## Verification
- parsed all issue-form YAML files successfully
- validated GitHub form keys, IDs, dropdown options, checkbox requirements, and existing labels
- `git diff --check`
- confirmed `.github/workflows/` and `.github/aw/` are unchanged

## Risks
Low. Repository metadata only; no runtime or workflow behavior changes. Contributors will be guided through structured forms instead of blank issues.

## Follow-ups
- a private security-reporting contact can be added if GitHub private vulnerability reporting is enabled later

Closes #313