### PR TITLE
test: add isolated Playwright E2E smoke tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,49 @@
+name: Playwright smoke tests
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'client/**'
+      - '.github/workflows/e2e.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  chromium-e2e:
+    name: Chromium E2E smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: client
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: client/.nvmrc
+          cache: npm
+          cache-dependency-path: client/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+      - name: Run smoke tests
+        run: npm run test:e2e
+      - name: Upload test results (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-failure-artifacts
+          path: |
+            client/test-results/
+            client/playwright-report/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ guess commands.
 | `npm run preview`    | `vite preview`                        |
 | `npm test`           | `vitest run`                          |
 | `npm run test:watch` | `vitest`                              |
+| `npm run test:e2e`   | `playwright test`                     |
 
 ### Backend (`backend/`)
 
@@ -128,7 +129,7 @@ The Vite dev server proxies `/api` requests to `http://localhost:5000`.
 | --------- | ------------------------------------------------------------- |
 | Backend   | Jest + Supertest + mongodb-memory-server. Route tests under `backend/routes/api/__test__/`. Run with `npm test` or `npm run test:ci` in `backend/`. |
 | Client    | Vitest + jsdom + Testing Library. Unit tests live under `client/src/` in `__tests__` directories. Run with `npm test` in `client/`. |
-| Playwright | Config exists (`client/playwright.config.ts`). First smoke tests are tracked in a separate issue (#316). |
+| Playwright | Smoke specs under `client/tests/`. Fully mocked API fixtures, Chromium-only, no production/external resources. Run with `npm run test:e2e` in `client/`. Prerequisite: `npx playwright install chromium`. |
 
 When verifying changes, run the **closest relevant check** for the layer you
 touched. For documentation-only edits, a build is not necessary.

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -55,7 +55,7 @@
         "zod": "^3.22.4"
       },
       "devDependencies": {
-        "@playwright/test": "^1.31.1",
+        "@playwright/test": "^1.62.0",
         "@testing-library/jest-dom": "^6.0.0",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.2",
@@ -1458,18 +1458,19 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.42.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.42.1.tgz",
-      "integrity": "sha512-Gq9rmS54mjBL/7/MvBaNOBwbfnh7beHvS6oS4srqXFcQHpQCV1+c8JXWE8VLPyRDhgS3H8x8A7hztqI9VnwrAQ==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
+      "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.42.1"
+        "playwright": "1.62.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=20"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -7288,33 +7289,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.42.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.42.1.tgz",
-      "integrity": "sha512-PgwB03s2DZBcNRoW+1w9E+VkLBxweib6KTXM0M3tkiT4jVxKSi6PmVJ591J+0u10LUrgxB7dLRbiJqO5s2QPMg==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.42.1"
+        "playwright-core": "1.62.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.42.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.42.1.tgz",
-      "integrity": "sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=20"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/client/package.json
+++ b/client/package.json
@@ -57,10 +57,11 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "playwright test"
   },
   "devDependencies": {
-    "@playwright/test": "^1.31.1",
+    "@playwright/test": "^1.62.0",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.2",

--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -1,90 +1,33 @@
 import { defineConfig, devices } from '@playwright/test';
 
-/**
- * Read environment variables from file.
- * https://github.com/motdotla/dotenv
- */
-// require('dotenv').config();
-
-/**
- * See https://playwright.dev/docs/test-configuration.
- */
 export default defineConfig({
   testDir: './tests',
-  /* Maximum time one test can run for. */
-  timeout: 30 * 1000,
-  expect: {
-    /**
-     * Maximum time expect() should wait for the condition to be met.
-     * For example in `await expect(locator).toHaveText();`
-     */
-    timeout: 5000,
-  },
-  /* Run tests in files in parallel */
   fullyParallel: true,
-  /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
+  retries: process.env.CI ? 1 : 0,
   workers: process.env.CI ? 1 : undefined,
-  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
-  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  outputDir: 'test-results',
+  reporter: [
+    ['list'],
+    ['html', { open: 'never', outputFolder: 'playwright-report' }],
+  ],
   use: {
-    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
-    actionTimeout: 0,
-    /* Base URL to use in actions like `await page.goto('/')`. */
-    // baseURL: 'http://localhost:3000',
-
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
+    baseURL: 'http://127.0.0.1:3000',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    serviceWorkers: 'block',
   },
-
-  /* Configure projects for major browsers */
   projects: [
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
     },
-
-    {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
-    },
-
-    {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
-    },
-
-    /* Test against mobile viewports. */
-    // {
-    //   name: 'Mobile Chrome',
-    //   use: { ...devices['Pixel 5'] },
-    // },
-    // {
-    //   name: 'Mobile Safari',
-    //   use: { ...devices['iPhone 12'] },
-    // },
-
-    /* Test against branded browsers. */
-    // {
-    //   name: 'Microsoft Edge',
-    //   use: { channel: 'msedge' },
-    // },
-    // {
-    //   name: 'Google Chrome',
-    //   use: { channel: 'chrome' },
-    // },
   ],
-
-  /* Folder for test artifacts such as screenshots, videos, traces, etc. */
-  // outputDir: 'test-results/',
-
-  /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npm run start',
-    port: 3000,
+    command: 'npm start -- --host 127.0.0.1',
+    url: 'http://127.0.0.1:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
   },
 });

--- a/client/tests/fixtures/auth.fixture.ts
+++ b/client/tests/fixtures/auth.fixture.ts
@@ -1,0 +1,15 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * Intercept the auth check endpoint and return 401 so the app renders
+ * in an unauthenticated state without reaching a real backend.
+ */
+export async function interceptUnauthenticatedAuth(page: Page) {
+  await page.route('**/api/user/auth', async (route) => {
+    await route.fulfill({
+      status: 401,
+      contentType: 'application/json',
+      body: JSON.stringify({ error: 'Unauthorized' }),
+    });
+  });
+}

--- a/client/tests/fixtures/book.fixture.ts
+++ b/client/tests/fixtures/book.fixture.ts
@@ -1,0 +1,49 @@
+export const MOCK_BOOK_ID = 'mock-book-id-001';
+export const MOCK_BOOK_TITLE = 'Test Book Title';
+
+export const DATA_URI_COVER =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+export const mockBook = {
+  _id: MOCK_BOOK_ID,
+  name: MOCK_BOOK_TITLE,
+  file: 'test-book.pdf',
+  date: '2024-01-15T12:00:00.000Z',
+  size: 1_048_576,
+  category: ['Fiction', 'Science'],
+  language: 'English',
+  url: 'https://example.com/test-book.pdf',
+  description: 'A test book for smoke testing.',
+  imageLinks: {
+    smallThumbnail: DATA_URI_COVER,
+    thumbnail: DATA_URI_COVER,
+  },
+  uploader: {
+    username: 'test-uploader',
+    _id: 'uploader-id-001',
+    email: 'uploader@example.com',
+  },
+};
+
+export const mockSearchResponse = {
+  results: [mockBook],
+  total: 1,
+  page: 1,
+  next: { page: 2 },
+  previous: { page: 0 },
+};
+
+export const mockRatingSummary = {
+  success: true,
+  data: { avgRating: 4.0, count: 5 },
+};
+
+export const mockReviews = {
+  success: true,
+  data: [] as Array<{
+    _id: string;
+    userId?: { username: string };
+    rating: number;
+    review?: string;
+  }>,
+};

--- a/client/tests/fixtures/external-block.fixture.ts
+++ b/client/tests/fixtures/external-block.fixture.ts
@@ -1,0 +1,25 @@
+import type { Page } from '@playwright/test';
+
+const BLOCKED_PATTERNS: RegExp[] = [
+  /google-analytics\.com/,
+  /googletagmanager\.com/,
+  /kitapkurdu\.onrender\.com/,
+  /images\.pexels\.com/,
+  /unpkg\.com/,
+  /\/sw\.js(\?|$|#)/,
+];
+
+/**
+ * Abort requests to external services that are not needed for smoke tests.
+ * Uses route.fallback() so more specific API route handlers (registered
+ * earlier) take precedence under Playwright's reverse registration order.
+ */
+export async function blockExternalRequests(page: Page) {
+  await page.route('**/*', (route) => {
+    const url = route.request().url();
+    if (BLOCKED_PATTERNS.some((p) => p.test(url))) {
+      return route.abort();
+    }
+    return route.fallback();
+  });
+}

--- a/client/tests/homepage.spec.ts
+++ b/client/tests/homepage.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+import { interceptUnauthenticatedAuth } from './fixtures/auth.fixture';
+import { blockExternalRequests } from './fixtures/external-block.fixture';
+
+test.describe('Homepage', () => {
+  test.beforeEach(async ({ page }) => {
+    await interceptUnauthenticatedAuth(page);
+    await blockExternalRequests(page);
+  });
+
+  test('renders search page with expected elements', async ({ page }) => {
+    const response = await page.goto('/');
+    expect(response?.ok()).toBeTruthy();
+
+    await expect(
+      page.getByRole('heading', { name: 'Search Books' })
+    ).toBeVisible();
+
+    await expect(
+      page.getByPlaceholder('Search for a book, author, or keyword...')
+    ).toBeVisible();
+
+    await expect(
+      page.getByRole('button', { name: 'Search' })
+    ).toBeVisible();
+
+    await expect(page.getByText('Start Your Search')).toBeVisible();
+  });
+});

--- a/client/tests/protected-route.spec.ts
+++ b/client/tests/protected-route.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+import { interceptUnauthenticatedAuth } from './fixtures/auth.fixture';
+import { blockExternalRequests } from './fixtures/external-block.fixture';
+
+test.describe('Protected route', () => {
+  test.beforeEach(async ({ page }) => {
+    await interceptUnauthenticatedAuth(page);
+    await blockExternalRequests(page);
+  });
+
+  test('redirects unauthenticated user from /profile to /login', async ({
+    page,
+  }) => {
+    await page.goto('/profile');
+    await page.waitForURL('**/login');
+
+    await expect(
+      page.getByRole('heading', { name: 'Welcome' })
+    ).toBeVisible();
+
+    await expect(
+      page.getByPlaceholder('Enter your username or email')
+    ).toBeVisible();
+
+    await expect(
+      page.getByPlaceholder('Enter your password')
+    ).toBeVisible();
+  });
+});

--- a/client/tests/search-to-book.spec.ts
+++ b/client/tests/search-to-book.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect } from '@playwright/test';
+import { interceptUnauthenticatedAuth } from './fixtures/auth.fixture';
+import { blockExternalRequests } from './fixtures/external-block.fixture';
+import {
+  MOCK_BOOK_ID,
+  MOCK_BOOK_TITLE,
+  mockSearchResponse,
+  mockBook,
+  mockRatingSummary,
+  mockReviews,
+} from './fixtures/book.fixture';
+
+test.describe('Search to book detail flow', () => {
+  test.beforeEach(async ({ page }) => {
+    // Auth check always returns 401 so the app renders unauthenticated.
+    await interceptUnauthenticatedAuth(page);
+
+    // Specific API routes must be registered BEFORE the global external-block
+    // catch-all so they take priority.
+    await page.route('**/api/books/searchBooks**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockSearchResponse),
+      });
+    });
+
+    await page.route(
+      `**/api/books/getBookById/${MOCK_BOOK_ID}`,
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(mockBook),
+        });
+      }
+    );
+
+    await page.route(
+      `**/api/ratings/summary/${MOCK_BOOK_ID}`,
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(mockRatingSummary),
+        });
+      }
+    );
+
+    await page.route(
+      `**/api/ratings/reviews/${MOCK_BOOK_ID}`,
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(mockReviews),
+        });
+      }
+    );
+
+    // Global external block LAST so it does not shadow the API routes above.
+    await blockExternalRequests(page);
+  });
+
+  test('searches for a book and navigates to its detail page', async ({
+    page,
+  }) => {
+    await page.goto('/');
+
+    // Fill the search form and submit
+    await page
+      .getByPlaceholder('Search for a book, author, or keyword...')
+      .fill('Test');
+    await page.getByRole('button', { name: 'Search' }).click();
+
+    // Verify search results
+    await expect(page.getByText('Search Results')).toBeVisible();
+    await expect(page.getByText('1 books found')).toBeVisible();
+    await expect(page.getByText(MOCK_BOOK_TITLE)).toBeVisible();
+
+    // Click View to navigate to book detail
+    await page.getByRole('link', { name: 'View' }).click();
+
+    // Verify book detail page
+    await expect(page).toHaveURL(`/book/${MOCK_BOOK_ID}`);
+    await expect(
+      page.getByRole('heading', { name: MOCK_BOOK_TITLE })
+    ).toBeVisible();
+
+    // Uploader username from the fixture
+    await expect(page.getByText('test-uploader')).toBeVisible();
+
+    // Description
+    await expect(
+      page.getByText('A test book for smoke testing.')
+    ).toBeVisible();
+
+    // Core detail and review sections
+    await expect(page.getByText('Book Details')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Reviews' })).toBeVisible();
+  });
+});

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,5 +1,6 @@
 /// <reference types="vitest/config" />
 import { defineConfig } from 'vite';
+import { configDefaults } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 
@@ -45,5 +46,6 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: './src/setupTests.ts',
+    exclude: [...configDefaults.exclude, 'tests/**'],
   },
 });

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -172,8 +172,28 @@ mongodb-memory-server binary to MongoDB 7.0.3 (`MONGOMS_VERSION`) for
 Linux runner compatibility (Debian 12).
 
 Client unit tests use Vitest with jsdom and Testing Library and avoid
-production services. Playwright E2E tests are tracked separately in
-[#316](/sayinmehmet47/kitapKurdu/issues/316) and are not yet part of CI.
+production services.
+
+#### Playwright E2E smoke (`e2e.yml`)
+
+A separate [`e2e.yml`](../.github/workflows/e2e.yml) workflow runs Playwright
+smoke tests on pull requests targeting `main` when `client/**` or the workflow
+itself changes. It can also be triggered manually via `workflow_dispatch`.
+
+| Aspect | Detail |
+| --- | --- |
+| **Browsers** | Chromium-only (Desktop Chrome). No Firefox or WebKit on PRs. |
+| **API strategy** | Every API call is intercepted at `page.route()` level with deterministic fixture JSON. No backend, MongoDB, Cloudinary, Render, or Vercel is required. |
+| **External services** | Google Analytics/Tag Manager, production Render API, Pexels, unpkg, and service worker registrations are blocked at the route level. |
+| **Isolation** | Fully mocked frontend-only; no network calls leave the browser except Vite dev-server requests for HTML/JS/CSS assets. |
+| **Artifacts** | `test-results/` and `playwright-report/` are uploaded only when the job fails (retention 7 days). |
+| **Concurrency** | Grouped by workflow + ref; in-progress runs on the same PR are cancelled. |
+| **Run command** | `npm run test:e2e` in `client/`. Prerequisite: `npx playwright install chromium`. |
+
+**Important:** These are **frontend smoke tests**, not a full-stack E2E suite.
+They validate that critical UI flows render correctly with mocked API responses.
+A future true full-stack E2E environment must use isolated test/staging
+resources and must never target production services or data.
 
 Branch protection should require both checks — `Backend build and tests` and
 `Client type-check and build` — to pass before merging, after the workflow has
@@ -198,4 +218,4 @@ mutate production data.
 | ---------- | -------------------------------------------------------------------------------------------------------- |
 | Backend    | Jest + Supertest + mongodb-memory-server. Route integration tests live under [`backend/routes/api/__test__/`](../backend/routes/api/__test__/). Run with `npm test` or `npm run test:ci` in `backend/`. |
 | Client     | Vitest + jsdom + Testing Library. Unit tests live under `client/src/` in `__tests__` directories. Run with `npm test` in `client/`. |
-| Playwright | Configuration exists at [`client/playwright.config.ts`](../client/playwright.config.ts). First smoke tests are tracked in issue [#316](/sayinmehmet47/kitapKurdu/issues/316). E2E tests are not yet part of CI. |
+| Playwright | Smoke specs under `client/tests/`. Fully mocked API fixtures (no backend, database, or external services). Chromium-only. Run with `npm run test:e2e` in `client/`. CI via [`e2e.yml`](../.github/workflows/e2e.yml). |


### PR DESCRIPTION
## Summary
- add Chromium Playwright smoke tests for homepage rendering, protected-route redirects, and search-to-book navigation
- use deterministic API fixtures and block external analytics, service workers, production API, and image/PDF hosts
- update Playwright to 1.62 and keep Vitest from collecting E2E specs
- add a non-deploying PR/manual GitHub Actions workflow with failure-only diagnostics
- document the mocked E2E isolation strategy and local command

## Verification
- client under Node 20: `npm ci`, `npm test`, and `npm run build` — passed (2 unit files, 9 tests)
- cached official Playwright 1.62 Docker image: `npm ci && npm run test:e2e` — 3 specs passed with no retries
- no backend, MongoDB, Cloudinary, Render, Vercel, or production credentials used
- `git diff --check`
- validated workflow/action tags, package-lock consistency, and documentation links

## Failure diagnostics
On failure, GitHub Actions uploads screenshots, videos, traces, and the HTML Playwright report as an artifact retained for 7 days. Successful runs do not upload visual artifacts.

## Risks
- mocked browser tests validate frontend journeys and API contracts, not the real backend/database integration
- CI downloads the matching Chromium browser on fresh GitHub-hosted runners

## Follow-ups
- true full-stack E2E should use an isolated local or staging backend/database and must never target production
- the unrelated App.tsx whitespace stash remains outside this change

Closes #316