### PR TITLE
docs: add comprehensive setup and deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,143 +1,376 @@
-<div align="center" id="top"> 
-  <img src="./.github/app.gif" alt="Shorturl" />
+# KitapKurdu
 
-&#xa0;
+A full-stack book search and sharing application with user authentication, book uploads,
+comments, and ratings. Built with React, Express, and MongoDB.
 
-  <!-- <a href="https://shorturl.netlify.app">Demo</a> -->
-</div>
+**Live**
 
-<h1 align="center">BOOK WORMS</h1>
+- Frontend: [https://kitap-kurdu-bx87.vercel.app](https://kitap-kurdu-bx87.vercel.app)
+- Backend health: [https://kitapkurdu.onrender.com/healthz](https://kitapkurdu.onrender.com/healthz)
+- Actions workflows: [repository Actions tab](https://github.com/sayinmehmet47/kitapKurdu/actions)
 
-<p align="center">
-  <img alt="Github top language" src="https://img.shields.io/github/languages/top/{{YOUR_GITHUB_USERNAME}}/shorturl?color=56BEB8">
+---
 
-  <img alt="Github language count" src="https://img.shields.io/github/languages/count/{{YOUR_GITHUB_USERNAME}}/shorturl?color=56BEB8">
+## Overview
 
-  <img alt="Repository size" src="https://img.shields.io/github/repo-size/{{YOUR_GITHUB_USERNAME}}/shorturl?color=56BEB8">
+| Layer      | Technology                                                            |
+| ---------- | --------------------------------------------------------------------- |
+| Client     | React 18, Vite 6, TypeScript, Redux Toolkit, Tailwind CSS, Radix UI   |
+| Backend    | Express 4, TypeScript, Mongoose (MongoDB), Passport (JWT, local, Google OAuth 2.0) |
+| Database   | MongoDB                                                               |
+| CI/CD      | GitHub Actions                                                        |
+| Formatting | Biome 2.5.6                                                           |
+| Deployment | Vercel (frontend), Render (backend)                                   |
+| Infra      | Kubernetes manifests (legacy, reference only)                         |
 
-  <img alt="License" src="https://img.shields.io/github/license/{{YOUR_GITHUB_USERNAME}}/shorturl?color=56BEB8">
+## Request flow
 
-  <!-- <img alt="Github issues" src="https://img.shields.io/github/issues/{{YOUR_GITHUB_USERNAME}}/shorturl?color=56BEB8" /> -->
+Both development and production use a same-origin `/api` strategy:
 
-  <!-- <img alt="Github forks" src="https://img.shields.io/github/forks/{{YOUR_GITHUB_USERNAME}}/shorturl?color=56BEB8" /> -->
+| Environment | `/api` resolution                                           |
+| ----------- | ----------------------------------------------------------- |
+| Dev         | Vite proxy → `http://localhost:5000`                         |
+| Prod        | Vercel rewrite → `https://kitapkurdu.onrender.com/api`      |
 
-  <!-- <img alt="Github stars" src="https://img.shields.io/github/stars/{{YOUR_GITHUB_USERNAME}}/shorturl?color=56BEB8" /> -->
-</p>
+The client always sends API requests to the same origin with `/api` as the base path.
+The canonical configuration relies on the Vite proxy in development and the
+[`vercel.json`](client/vercel.json) rewrite rule in production. The optional
+`VITE_PROD_API` build-time variable can override the path, but leaving it unset
+(defaults to `/api`) is the recommended configuration.
 
-<!-- Status -->
+## Prerequisites
 
-<!-- <h4 align="center">
-	🚧  Shorturl 🚀 Under construction....  🚧
-</h4>
+- [Git](https://git-scm.com)
+- [Node.js](https://nodejs.org) 20.x (pinned via `engines.node` in both `client/package.json` and `backend/package.json`)
+- [MongoDB](https://www.mongodb.com) (local instance or [Atlas](https://www.mongodb.com/atlas))
+- [Forego](https://github.com/ddollar/forego) (required only for the combined `npm run local` command). Install via `brew install forego` on macOS, or follow the [official build instructions](https://github.com/ddollar/forego#installation). Contributors without Forego can use the separate `npm run local:backend` and `npm run local:frontend` terminals instead.
+- A [Google Cloud](https://console.cloud.google.com) OAuth 2.0 client (for social login). **Required** by backend startup validation even if you only use local/password auth — the backend won't start without `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`.
+- [Cloudinary](https://cloudinary.com) account (for book cover uploads). Optional for local browsing.
+- [EmailJS](https://www.emailjs.com) account (for contact form). Optional.
 
-<hr> -->
-
-<p align="center">
-  <a href="#dart-about">About</a> &#xa0; | &#xa0; 
-  <a href="#sparkles-features">Features</a> &#xa0; | &#xa0;
-  <a href="#rocket-technologies">Technologies</a> &#xa0; | &#xa0;
-  <a href="#white_check_mark-requirements">Requirements</a> &#xa0; | &#xa0;
-  <a href="#checkered_flag-starting">Starting</a> &#xa0; | &#xa0;
-  <a href="#books-documentation">Documentation</a> &#xa0; | &#xa0;
-  <a href="#memo-license">License</a> &#xa0; | &#xa0;
-  <a href="https://github.com/sayinmehmet47" target="_blank">Author</a>
-</p>
-
-<br>
-
-## :dart: About
-
-This project comprises 5000 Turkish books available for free. I used Cloudinary to fetch and upload new books. The books are searchable, and you can access the entire library as well as monitor the latest additions. If a user cannot find a specific book in the library, they can add a comment to request assistance from other users. Other users can contribute to the library without limitations. The admin has a distinct role that allows them to delete comments and books.
-
-The project is primarily built using ReactJS for the frontend, NodeJS for the backend, and is deployed on a Kubernetes cluster within Rancher. Additionally, I have deployed the app on Vercel, making it accessible from both the Kubernetes cluster and Vercel. When you open a pull request, automated tests will run, and your pull request will be awaiting approval. After the pull request is merged, the app will be built and simultaneously pushed to Docker Hub and Vercel. Following the completion of the app's building process in GitHub Actions, the Kubernetes cluster will be triggered to run the new image we pushed to Docker Hub, ensuring it uses the latest version. You can also run the app locally using Docker, but you'll need to obtain your own MongoDB,Cloudinary secrets and add it to the environment file.
-For updating the npm package, i used as a bot renovate. It opens pr for the outdated package periodically.
-If new book added to library user get a notification
-
-This project is my side project, where I mostly implement new concepts and technologies I've learned. It covers most of the technologies required for a real-world application. Currently, there are 300 active users registered with and using this app.
-
-
-![image](https://github.com/sayinmehmet47/kitapKurdu/assets/75525090/e7913605-ef0a-429e-a166-166dd10c0869)
-
-![image](https://github.com/sayinmehmet47/kitapKurdu/assets/75525090/b8f621b1-c6ac-4756-b7ab-cae86ba33391)
-
-![image](https://github.com/sayinmehmet47/kitapKurdu/assets/75525090/ab7ea536-c764-4556-9167-9d554393b164)
-
-<img width="452" alt="image" src="https://github.com/sayinmehmet47/kitapKurdu/assets/75525090/716a4150-0451-4933-839f-611d17efc4c4">
-
-
-
-## :sparkles: Features
-
-:heavy_check_mark: You can install more than 7000 books free with one click
-
-:heavy_check_mark: Books are in e-pub format
-
-:heavy_check_mark: Logged in user can add new books
-
-## :rocket: Technologies
-
-The following tools were used in this project:
-
-- [x] ReactJS
-- [x] Tailwind
-- [x] MongoDB
-- [x] Typescript
-- [x] NodeJS
-- [x] Kubernetes
-- [x] Github Actions
-- [x] Integration test for backend
-- [x] Prometheus
-- [x] Graphana
-- [x] Renovate
-- [x] Docker
-- [x] Cronjob
-- [x] Caching(Node Cache)
-- [x] Service Workers
-- [x] Google Analytics
-
-
-## :white_check_mark: Requirements
-
-Before starting :checkered_flag:, you need to have [Git](https://git-scm.com) and [Node](https://nodejs.org/en/) installed.
-
-## :checkered_flag: Starting
+## Quick start
 
 ```bash
-# Clone this project
-$ git clone https://github.com/sayinmehmet47/kitapKurdu.git
+# Clone the repository
+git clone https://github.com/sayinmehmet47/kitapKurdu.git
+cd kitapKurdu
 
+# Install dependencies (three workspaces)
+npm ci                          # root (Biome)
+npm ci --prefix client          # client
+npm ci --prefix backend         # backend
 
-$ cd client
-$ npm install
-$ npm run start
+# Copy and fill environment files
+cp client/.env.example client/.env
+cp backend/.env.example backend/.env
+```
 
-// in another terminal
+Edit both `.env` files and fill in the required values (see [Environment
+variables](#environment-variables) below). The backend validates these eight
+variables at startup and exits if any are missing: `MONGO_URI`,
+`ACCESS_TOKEN_SECRET_KEY`, `REFRESH_TOKEN_SECRET_KEY`, `JWT_SECRET`, `PORT`,
+`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, and `CLIENT_URL`.
 
-$ cd backend
+```bash
+# Start both frontend and backend
+npm run local
+```
 
-$ npm install
-$ npm run start
+This requires [Forego](https://github.com/ddollar/forego) (see [Prerequisites](#prerequisites) for
+install instructions). It launches the frontend and backend in parallel
+(see [`Procfile.local`](Procfile.local)).
 
-#create a env file and attach your mongodb url
+If you don't have Forego, start each service independently in separate terminals:
 
+```bash
+# Terminal 1 — Backend (port 5000)
+npm run local:backend
 
-$ cd ..
+# Terminal 2 — Frontend (port 3000)
+npm run local:frontend
+```
 
+| Service | URL                        | Notes                                      |
+| ------- | -------------------------- | ------------------------------------------ |
+| Client  | http://localhost:3000      | Vite dev server, hot reload                 |
+| Backend | http://localhost:5000      | ts-node-dev with watch mode                 |
 
+> **Note:** The backend `npm start` script runs the compiled output (`node ./dist/index.js`)
+> and requires `npm run build` first. For local development, use `npm run dev` instead.
 
+## Environment variables
 
+Only variable **names** are listed. Actual values are managed through `.env` files
+(local), platform dashboards (Vercel/Render), or CI secrets — never commit them.
 
-## :books: Documentation
+### Backend
 
-- [Agent instructions](AGENTS.md) — commands, workflow, security, and testing guidance for contributors and automation.
-- [Architecture](docs/architecture.md) — current repository architecture, data flow, API routes, environment variables, deployment topology, and test state.
+**Required at startup** (backend exits if any are missing):
 
-## :memo: License
+| Variable                     | Purpose                                                 |
+| ---------------------------- | ------------------------------------------------------- |
+| `MONGO_URI`                  | MongoDB connection string                               |
+| `ACCESS_TOKEN_SECRET_KEY`    | JWT access token signing secret                         |
+| `REFRESH_TOKEN_SECRET_KEY`   | JWT refresh token signing secret                        |
+| `JWT_SECRET`                 | Legacy startup-validation requirement (token logic uses access/refresh keys above) |
+| `PORT`                       | Server port (Render injects automatically; set manually for local dev) |
+| `GOOGLE_CLIENT_ID`           | Google OAuth 2.0 client ID                              |
+| `GOOGLE_CLIENT_SECRET`       | Google OAuth 2.0 client secret                          |
+| `CLIENT_URL`                 | Frontend URL for redirects and OAuth callbacks                 |
 
-This project is under license from MIT. For more details, see the [LICENSE](LICENSE.md) file.
+**Operational** (referenced at runtime but not validated at startup):
 
-Made with :heart: by <a href="https://github.com/sayinmehmet47" target="_blank">Mehmet Sayin</a>
+| Variable                | Purpose                                            |
+| ----------------------- | -------------------------------------------------- |
+| `NODE_ENV`              | Node environment (`production`, `development`, `test`) |
+| `SERVER_URL`            | Public URL of the backend (OAuth callbacks, sitemap) |
+| `GOOGLE_CALLBACK_URL`   | Google OAuth redirect URI                           |
 
-&#xa0;
+**Optional — Email** (features silently degrade if unset; `EMAIL_USER` and `EMAIL_PASS`
+are both required for SMTP auth when enabled):
 
-<a href="#top">Back to top</a>
+| Variable           | Purpose                | Note                      |
+| ------------------ | ---------------------- | ------------------------- |
+| `EMAIL_USER`       | SMTP username          | Required if email enabled |
+| `EMAIL_PASS`       | SMTP password          | Required if email enabled |
+| `EMAIL_HOST`       | SMTP host              |                           |
+| `EMAIL_PORT`       | SMTP port              |                           |
+| `EMAIL_FROM`       | From address           |                           |
+| `EMAIL_FROM_NAME`  | From display name      |                           |
+
+### Client
+
+All `VITE_*` variables are embedded in the JavaScript bundle at build time
+and are **publicly visible** in the browser. Never store private credentials in them.
+
+**Actively consumed:**
+
+| Variable                              | Purpose                                        | Default                  |
+| ------------------------------------- | ---------------------------------------------- | ------------------------ |
+| `VITE_PROD_API`                       | Override API base path in production            | unset → `/api`           |
+| `VITE_CLOUDINARY_URL`                 | Cloudinary base URL for image uploads          | (required for uploads)   |
+| `VITE_PUBLIC_EMAILJS_SERVICE_ID`      | EmailJS service ID (contact form)               | (required for contact form) |
+| `VITE_PUBLIC_EMAILJS_TEMPLATE_ID`     | EmailJS template ID (contact form)              | (required for contact form) |
+| `VITE_PUBLIC_EMAILJS_PUBLIC_KEY`      | EmailJS public key (contact form)               | (required for contact form) |
+
+`VITE_PROD_API` is optional. When unset, the production API path defaults to `/api`
+and is rewritten to the Render backend by the Vercel rewrite rule. Setting it to a full
+URL stores that URL in the public bundle — prefer leaving it unset unless you have a
+specific reason.
+
+The variables `VITE_LOCAL_API` and `VITE_DEV_API` are no longer actively consumed by the
+codebase and should not be relied upon.
+
+### Test-only
+
+The backend test suite uses isolated in-memory MongoDB via `mongodb-memory-server`.
+Optionally, you can override this with:
+
+| Variable          | Purpose                                  |
+| ----------------- | ---------------------------------------- |
+| `TEST_MONGO_URI`  | Custom MongoDB URI for test isolation     |
+| `TEST_MONGO_DB`   | Custom database name for test isolation   |
+
+These are not required. Without them, tests default to an ephemeral in-memory instance.
+
+## Commands
+
+### Root
+
+| Command                    | Script                                                                                   |
+| -------------------------- | ---------------------------------------------------------------------------------------- |
+| `npm run local`            | Starts frontend + backend via Forego                                                      |
+| `npm run local:frontend`   | `npm --prefix ./client start`                                                             |
+| `npm run local:backend`    | `PORT=5000 npm --prefix ./backend run dev`                                                 |
+| `npm run check`            | Reports format/lint issues on staged files (`biome check --staged --no-errors-on-unmatched .`) |
+| `npm run check:write`      | Formats and applies safe fixes to staged files (`biome check --write --staged --no-errors-on-unmatched .`) |
+| `npm run check:ci`         | Read-only check of changed files vs `origin/main` (`biome ci --changed --since=origin/main --no-errors-on-unmatched .`) |
+| `npm run check:all`        | Audits all supported files; currently reports legacy debt (`biome check .`)                  |
+
+> `npm test` at the root is a placeholder and must not be used for verification.
+
+### Client (`client/`)
+
+| Command                  | Script                     |
+| ------------------------ | -------------------------- |
+| `npm start`              | `vite` (dev, port 3000)    |
+| `npm run build`          | `tsc && vite build`        |
+| `npm run preview`        | `vite preview`             |
+| `npm test`               | `vitest run`               |
+| `npm run test:watch`     | `vitest` (watch mode)      |
+| `npm run test:e2e`       | `playwright test`          |
+
+### Backend (`backend/`)
+
+| Command              | Script                                                              |
+| -------------------- | ------------------------------------------------------------------- |
+| `npm run dev`        | `ts-node-dev --respawn --transpile-only --ignore-watch node_modules index.ts` (watch mode)  |
+| `npm run build`      | `tsc -p tsconfig.build.json`                                        |
+| `npm start`          | `node ./dist/index.js` (**requires `npm run build` first**)          |
+| `npm test`           | `jest --no-cache`                                                   |
+| `npm run test:ci`    | `jest`                                                              |
+
+## Testing
+
+| Area       | Stack                                                   | Command (in directory)   |
+| ---------- | ------------------------------------------------------- | ------------------------ |
+| Backend    | Jest, Supertest, mongodb-memory-server                  | `npm test` in `backend/` |
+| Client     | Vitest, jsdom, Testing Library                          | `npm test` in `client/`  |
+| Playwright | Chromium-only, fully mocked API fixtures, no external services | `npm run test:e2e` in `client/` |
+
+**Playwright prerequisite:** Install Chromium before running E2E tests:
+
+```bash
+npx playwright install chromium
+```
+
+Backend tests use isolated in-memory MongoDB and never target production services.
+Client unit tests avoid production/external resources.
+
+CI runs backend tests serially (`--runInBand`) with `MONGOMS_VERSION` pinned to MongoDB
+7.0.3 for Linux runner compatibility. E2E tests run via a separate
+[`e2e.yml`](.github/workflows/e2e.yml) workflow, triggered on PRs when client files
+change or manually via `workflow_dispatch`.
+
+## Code quality
+
+Biome 2.5.6 handles formatting, linting, and import organization from a single root
+[`biome.json`](biome.json). Type-checking is performed separately by `tsc` during
+`npm run build` in both `client/` and `backend/`.
+
+**Before committing:**
+
+1. Stage the files you intend to commit.
+2. Run `npm run check:write` to apply formatting and safe auto-fixes.
+3. Review and re-stage any automatic changes.
+4. Run `npm run check` to verify no issues remain.
+
+There is no pre-commit hook. Formatting is manual and deliberate. CI runs
+`npm run check:ci` in read-only (non-mutating) mode.
+
+`npm run check:all` audits all supported files and currently reports legacy debt tracked
+in issue [#328](https://github.com/sayinmehmet47/kitapKurdu/issues/328).
+
+## GitHub / OpenCode workflow
+
+1. **One issue per branch.** Create a dedicated branch from `main`.
+2. **Read [`AGENTS.md`](AGENTS.md) first.** It defines verified commands, security
+   boundaries, and the definition of done.
+3. **Bounded changes.** Only modify files and directories that the issue scope
+   authorises.
+4. **PR description** must include `Closes #<number>`.
+5. **Required checks** — _Backend build and tests_ and _Client type-check and build_ —
+   run on every PR. Review the CI results and preview deployments before requesting a
+   merge.
+6. **The operator merges.** Agents and automation do not merge, push, or deploy without
+   explicit operator approval.
+
+The [`.opencode/`](.opencode/) project overrides (in `.opencode/agents/`) reduce agent prompt
+confirms but do not authorise merge, deploy, or secret access.
+
+## Deployment
+
+### Vercel (frontend)
+
+The client is deployed to Vercel with the following configuration (mirrored in
+[`client/vercel.json`](client/vercel.json)):
+
+| Setting            | Value                                                  |
+| ------------------ | ------------------------------------------------------ |
+| Root Directory     | `client`                                               |
+| Build Command      | `npm run build`                                         |
+| Output Directory   | `build`                                                |
+| Node.js Version    | 20.x (pinned via `engines.node` in `client/package.json`) |
+| Rewrites           | `/api/:path*` → `https://kitapkurdu.onrender.com/api/:path*` |
+
+Merging to `main` triggers an automatic Vercel deployment. Frontend-only PRs receive
+preview URLs for manual verification.
+
+### Render (backend)
+
+The backend is deployed to Render via the Blueprint defined in
+[`render.yaml`](render.yaml):
+
+| Setting            | Value                                         |
+| ------------------ | --------------------------------------------- |
+| Type               | Web service                                   |
+| Runtime            | Node                                          |
+| Root Directory     | `backend`                                     |
+| Build Command      | `npm ci && npm run build`                      |
+| Start Command      | `npm run start`                                |
+| Health Check       | `/healthz`                                     |
+| Plan               | Free                                          |
+| Region             | Oregon                                        |
+| Auto Deploy        | Off                                           |
+| Previews           | Automatic                                     |
+
+**Important:** Adding `render.yaml` alone does not deploy the service. The Blueprint
+must be reviewed and manually adopted in the Render dashboard to avoid creating a
+duplicate service. After adoption, sync the environment variables from the dashboard
+(names only in the file).
+
+**Free-tier cold starts:** The Render free plan spins down after inactivity. Expect a
+delay on the first request after idle periods.
+
+### Kubernetes (legacy, reference only)
+
+Manifests under [`infra/k8s/`](infra/k8s/), [`infra/k8s-dev/`](infra/k8s-dev/),
+[`infra/k8s-staging/`](infra/k8s-staging/), [`infra/secrets/`](infra/secrets/), and
+[`infra/workflows-legacy/`](infra/workflows-legacy/) are retained for historical
+reference and are **not** actively deployed. Do not re-enable or reactivate them unless
+an explicit issue requests it.
+
+## Troubleshooting
+
+**Backend fails to start — missing environment variables.**
+Ensure `backend/.env` exists and all required variables are set. The backend validates
+`MONGO_URI`, `ACCESS_TOKEN_SECRET_KEY`, `REFRESH_TOKEN_SECRET_KEY`, `JWT_SECRET`,
+`PORT`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, and `CLIENT_URL` at startup.
+
+**MongoDB connection refused.**
+Verify MongoDB is running locally (`mongod`) or your Atlas cluster is accessible.
+Check that `MONGO_URI` is correct and network access allows the connection.
+
+**Port 3000 or 5000 already in use.**
+Free the port (`lsof -i :3000` / `lsof -i :5000` → `kill -9 <PID>`) or override with
+environment variables. In `backend/.env`, set `PORT` to a free port and adjust the Vite
+proxy target in [`client/vite.config.ts`](client/vite.config.ts) accordingly.
+
+**Render deployment: cold start or health check failures.**
+The free plan spins down after inactivity — the first request may be slow. If the service
+is permanently down, check the Render dashboard for crash logs, verify environment
+variables, and confirm `/healthz` returns 200. The `keepalive.yml` cron workflow has
+been removed; cold starts are expected.
+
+**CORS errors in the browser.**
+Allowed cross-origin origins are defined by the explicit allowlist in
+[`backend/app.ts`](backend/app.ts) (line 29), not by `CLIENT_URL`. `CLIENT_URL` is
+validated at startup and used for redirects and links, but adding a new frontend
+origin to the application requires a reviewed change to the `origin` array in
+`backend/app.ts`.
+
+**API requests failing in production — wrong base URL.**
+The canonical Vercel deployment uses the same-origin `/api` path rewritten to Render.
+If you set `VITE_PROD_API`, that value overrides the path and is embedded in the public
+bundle. Prefer leaving it unset. Clear the Vercel dashboard environment variable if it
+was set previously.
+
+**Playwright tests fail — browser not found.**
+Run `npx playwright install chromium` in the `client/` directory. CI installs the
+required system dependencies automatically.
+
+**Biome doesn't see your files — no issues reported.**
+Biome runs against staged files by default (`check` / `check:write`). Verify your files
+are staged (`git status`). If they are and still ignored, check the `includes` patterns
+in [`biome.json`](biome.json).
+
+## Documentation
+
+- [`AGENTS.md`](AGENTS.md) — Commands, workflow, security boundaries, testing guidance
+- [`docs/architecture.md`](docs/architecture.md) — Architecture, data flow, API routes,
+  environment variables, deployment topology
+- [`.github/ISSUE_TEMPLATE/`](.github/ISSUE_TEMPLATE/) — Issue templates
+- [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) — PR template
+- [`render.yaml`](render.yaml) — Render Blueprint configuration
+- [`client/vercel.json`](client/vercel.json) — Vercel deployment configuration
+- [`biome.json`](biome.json) — Biome formatting and linting configuration

--- a/client/README.md
+++ b/client/README.md
@@ -1,70 +1,147 @@
-# Getting Started with Create React App
+# KitapKurdu Client
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+React 18 frontend for the KitapKurdu book search and sharing application. Built with Vite 6,
+TypeScript, Redux Toolkit, Tailwind CSS, and Radix UI.
 
-## Available Scripts
+- [Root README](../README.md) — Full project overview, setup, deployment
+- [`docs/architecture.md`](../docs/architecture.md) — Architecture, data flow, API routes
 
-In the project directory, you can run:
+## Prerequisites
 
-### `yarn start`
+- [Node.js](https://nodejs.org) 20.x (pinned via `engines.node` in `package.json`)
+- Backend running on port 5000 (see [root quick start](../README.md#quick-start))
 
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+## Setup
 
-The page will reload if you make edits.\
-You will also see any lint errors in the console.
+```bash
+cd client
+npm ci
+cp .env.example .env   # fill in Cloudinary/EmailJS values (optional)
+npm start              # Vite dev server on port 3000
+```
 
-### `yarn test`
+The Vite dev server proxies `/api` requests to `http://localhost:5000`. The canonical
+API path is `/api` in both development and production — see the [request flow
+explanation](../README.md#request-flow) in the root README.
 
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+## Scripts
 
-### `yarn build`
+| Command                  | Purpose                                                |
+| ------------------------ | ------------------------------------------------------ |
+| `npm start`              | Vite dev server (port 3000, hot reload)                 |
+| `npm run build`          | TypeScript check + production bundle (`tsc && vite build`) |
+| `npm run preview`        | Preview the production build locally                     |
+| `npm test`               | Run Vitest unit tests                                    |
+| `npm run test:watch`     | Run Vitest in watch mode                                 |
+| `npm run test:e2e`       | Run Playwright smoke tests                               |
 
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
+## Directory map
 
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
+```
+client/
+├── src/
+│   ├── main.tsx            # Entry point
+│   ├── pages/              # Route-level components (Home, Books, Login, etc.)
+│   ├── components/         # Shared UI components (Navbar, Footer, Search, etc.)
+│   ├── redux/              # Redux store, slices, API helper
+│   ├── helpers/            # Utility functions
+│   ├── constants/          # Application constants
+│   ├── lib/                # Shared library code
+│   └── book-table/         # Book table components
+├── tests/                  # Playwright E2E specs
+├── vite.config.ts          # Vite config (port 3000, /api proxy, build)
+└── vercel.json             # Vercel deployment config
+```
 
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
+## Environment variables
 
-### `yarn eject`
+All `VITE_*` variables are embedded in the JavaScript bundle at build time and are
+**publicly visible** in the browser. Never store private credentials in them.
 
-**Note: this is a one-way operation. Once you `eject`, you can’t go back!**
+| Variable                              | Purpose                                        | Default                  |
+| ------------------------------------- | ---------------------------------------------- | ------------------------ |
+| `VITE_PROD_API`                       | Override API base path in production            | unset → `/api`           |
+| `VITE_CLOUDINARY_URL`                 | Cloudinary base URL for image uploads          | (required for uploads)   |
+| `VITE_PUBLIC_EMAILJS_SERVICE_ID`      | EmailJS service ID (contact form)               | (required for contact form) |
+| `VITE_PUBLIC_EMAILJS_TEMPLATE_ID`     | EmailJS template ID (contact form)              | (required for contact form) |
+| `VITE_PUBLIC_EMAILJS_PUBLIC_KEY`      | EmailJS public key (contact form)               | (required for contact form) |
 
-If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
+`VITE_PROD_API` is optional. When unset, the production API path defaults to `/api` and
+is rewritten to the Render backend by the Vercel rewrite rule in
+[`vercel.json`](vercel.json). Setting it to a full URL stores that URL in the public
+bundle — prefer leaving it unset.
 
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
+The variables `VITE_LOCAL_API` and `VITE_DEV_API` are **not** actively consumed by the
+codebase and should not be relied upon.
 
-You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
+## Testing
 
-## Learn More
+### Unit tests (Vitest)
 
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
+```bash
+npm test              # single run
+npm run test:watch    # watch mode
+```
 
-To learn React, check out the [React documentation](https://reactjs.org/).
+- **Framework:** Vitest with jsdom environment
+- **Utilities:** Testing Library (React, jest-dom, user-event)
+- Tests live in `__tests__` directories under `src/`
 
-### Code Splitting
+### E2E smoke tests (Playwright)
 
-This section has moved here: [https://facebook.github.io/create-react-app/docs/code-splitting](https://facebook.github.io/create-react-app/docs/code-splitting)
+```bash
+npx playwright install chromium   # prerequisite (one-time)
+npm run test:e2e
+```
 
-### Analyzing the Bundle Size
+- **Browsers:** Chromium only
+- **API strategy:** All API calls are intercepted at `page.route()` level with
+  deterministic fixture JSON — no backend, database, Cloudinary, or external
+  services required
+- **External services blocked:** Google Analytics, Tag Manager, production Render
+  API, Pexels, unpkg, and service worker registrations
+- **Isolation:** Fully mocked frontend-only. No network calls leave the browser
+  except Vite dev-server asset requests
 
-This section has moved here: [https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size](https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size)
+## Deployment
 
-### Making a Progressive Web App
+The client is deployed to Vercel. See [the root README's Deployment
+section](../README.md#vercel-frontend) for the complete configuration and the
+[`vercel.json`](vercel.json) file for the build and rewrite rules.
 
-This section has moved here: [https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app](https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app)
+| Setting            | Value                          |
+| ------------------ | ------------------------------ |
+| Root Directory     | `client`                       |
+| Build Command      | `npm run build`                 |
+| Output Directory   | `build`                        |
+| Node.js Version    | 20.x                           |
 
-### Advanced Configuration
+Merging to `main` triggers an automatic deployment. Frontend-only PRs receive preview
+URLs.
 
-This section has moved here: [https://facebook.github.io/create-react-app/docs/advanced-configuration](https://facebook.github.io/create-react-app/docs/advanced-configuration)
+The backend runs on Render (`https://kitapkurdu.onrender.com`). API requests are
+rewritten by Vercel to the backend — the client does not reference the Render URL
+directly in its source code (unless `VITE_PROD_API` is explicitly overridden).
 
-### Deployment
+## Troubleshooting
 
-This section has moved here: [https://facebook.github.io/create-react-app/docs/deployment](https://facebook.github.io/create-react-app/docs/deployment)
+**API requests return 404 or CORS errors.**
+The Vite dev server must be running (port 3000) and proxying to the backend (port 5000).
+Verify the backend is up at `http://localhost:5000/healthz`. For CORS errors in
+production, verify that the Vercel domain is in the explicit origin allowlist in
+`backend/app.ts`; `CLIENT_URL` controls redirects/OAuth/email links and does not
+dynamically update CORS.
 
-### `yarn build` fails to minify
+**Production builds hitting the wrong API URL.**
+Check the Vercel dashboard environment variables. If `VITE_PROD_API` is set, it
+overrides the canonical `/api` path. Remove it or set it back to `/api`. Remember that
+all `VITE_*` values are public — do not store the Render URL as a secret.
 
-This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)
+**Playwright tests fail — browser not found.**
+Run `npx playwright install chromium` in the `client/` directory to install the
+required browser binary.
+
+**Biome formatting (from repo root).**
+Biome operates from the repository root via the root `package.json` scripts. Run
+`npm run check:write` and `npm run check` from the root directory — not from
+`client/`.


### PR DESCRIPTION
## Summary
- replace the outdated root template README with an accurate project overview and onboarding guide
- replace the Create React App client README with Vite-specific setup, scripts, testing, and deployment guidance
- document environment-variable names, local commands, Biome, GitHub/OpenCode workflow, and isolated tests
- document Vercel as the active frontend target, Render as the manually managed backend target, and Kubernetes as legacy reference infrastructure
- add troubleshooting for startup checks, MongoDB, CORS, Render cold starts, Playwright, and staged Biome checks

## Verification
- validated all displayed commands against root/client/backend package scripts
- validated Markdown fences, headings, and table structure
- validated all repository-relative links and referenced paths
- checked external documentation/project links
- confirmed no secret values, stale CRA/template content, broken images, license claims, unverified metrics, or active-Kubernetes claims
- `git diff --check`
- `npm run check:write` and `npm run check` passed with Markdown excluded as documented
- documentation-only change; application builds/tests were not required

## Risks
Low. Documentation-only change with no runtime impact. Provider dashboard steps remain explicitly manual and no deployment is triggered by the documentation itself.

## Follow-ups
- reduce existing Biome baseline debt incrementally in #328
- decide and add an explicit repository license in a separate issue if desired

Closes #318