### PR TITLE
fix: remove unused client imports and catch bindings

### DIFF
--- a/client/src/components/User.tsx
+++ b/client/src/components/User.tsx
@@ -1,28 +1,13 @@
+import { BookOpen, Calendar, LogOut, Mail, Settings, Shield, User } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
-import { logoutThunk } from '../redux/authSlice';
-import { RootState, useAppDispatch, useAppSelector } from '@/redux/store';
 import { toast } from 'sonner';
-import {
-  User,
-  Mail,
-  Shield,
-  Calendar,
-  LogOut,
-  Settings,
-  BookOpen,
-} from 'lucide-react';
-
-import {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-  CardContent,
-} from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
+import { type RootState, useAppDispatch, useAppSelector } from '@/redux/store';
+import { logoutThunk } from '../redux/authSlice';
 
 export default function UserProfile() {
   const dispatch = useAppDispatch();
@@ -37,7 +22,7 @@ export default function UserProfile() {
       await dispatch(logoutThunk()).unwrap();
       toast.success('Successfully logged out');
       navigate('/');
-    } catch (error) {
+    } catch {
       toast.error('Logout failed');
     }
   };
@@ -56,9 +41,7 @@ export default function UserProfile() {
         {/* Header */}
         <div className="text-center space-y-2">
           <h1 className="text-3xl font-bold tracking-tight">Profile</h1>
-          <p className="text-muted-foreground">
-            Manage your account settings and preferences
-          </p>
+          <p className="text-muted-foreground">Manage your account settings and preferences</p>
         </div>
 
         {/* Profile Card */}
@@ -86,12 +69,8 @@ export default function UserProfile() {
                   <User className="h-5 w-5 text-primary" />
                 </div>
                 <div className="flex-1">
-                  <p className="text-sm font-medium text-muted-foreground">
-                    Username
-                  </p>
-                  <p className="text-lg font-semibold">
-                    {username || 'Not set'}
-                  </p>
+                  <p className="text-sm font-medium text-muted-foreground">Username</p>
+                  <p className="text-lg font-semibold">{username || 'Not set'}</p>
                 </div>
               </div>
 
@@ -100,9 +79,7 @@ export default function UserProfile() {
                   <Mail className="h-5 w-5 text-primary" />
                 </div>
                 <div className="flex-1">
-                  <p className="text-sm font-medium text-muted-foreground">
-                    Email
-                  </p>
+                  <p className="text-sm font-medium text-muted-foreground">Email</p>
                   <p className="text-lg font-semibold">{email || 'Not set'}</p>
                 </div>
               </div>
@@ -112,14 +89,9 @@ export default function UserProfile() {
                   <Shield className="h-5 w-5 text-primary" />
                 </div>
                 <div className="flex-1">
-                  <p className="text-sm font-medium text-muted-foreground">
-                    Role
-                  </p>
+                  <p className="text-sm font-medium text-muted-foreground">Role</p>
                   <div className="flex items-center space-x-2">
-                    <Badge
-                      variant={isAdmin ? 'default' : 'secondary'}
-                      className="text-sm"
-                    >
+                    <Badge variant={isAdmin ? 'default' : 'secondary'} className="text-sm">
                       {isAdmin ? 'Administrator' : 'User'}
                     </Badge>
                   </div>
@@ -141,9 +113,7 @@ export default function UserProfile() {
                   <Settings className="h-4 w-4 mr-2" />
                   <div className="text-left">
                     <div className="font-medium">Edit Profile</div>
-                    <div className="text-xs text-muted-foreground">
-                      Update your information
-                    </div>
+                    <div className="text-xs text-muted-foreground">Update your information</div>
                   </div>
                 </Button>
 
@@ -155,9 +125,7 @@ export default function UserProfile() {
                   <BookOpen className="h-4 w-4 mr-2" />
                   <div className="text-left">
                     <div className="font-medium">My Books</div>
-                    <div className="text-xs text-muted-foreground">
-                      View your library
-                    </div>
+                    <div className="text-xs text-muted-foreground">View your library</div>
                   </div>
                 </Button>
               </div>
@@ -168,11 +136,7 @@ export default function UserProfile() {
             {/* Account Actions */}
             <div className="space-y-3">
               <h3 className="text-lg font-semibold">Account</h3>
-              <Button
-                variant="destructive"
-                onClick={handleLogout}
-                className="w-full"
-              >
+              <Button variant="destructive" onClick={handleLogout} className="w-full">
                 <LogOut className="h-4 w-4 mr-2" />
                 Sign Out
               </Button>
@@ -191,20 +155,13 @@ export default function UserProfile() {
           <CardContent>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
               <div>
-                <span className="font-medium text-muted-foreground">
-                  Member since:
-                </span>
+                <span className="font-medium text-muted-foreground">Member since:</span>
                 <p className="mt-1">Recently joined</p>
               </div>
               <div>
-                <span className="font-medium text-muted-foreground">
-                  Account status:
-                </span>
+                <span className="font-medium text-muted-foreground">Account status:</span>
                 <div className="mt-1">
-                  <Badge
-                    variant="outline"
-                    className="text-green-600 border-green-200"
-                  >
+                  <Badge variant="outline" className="text-green-600 border-green-200">
                     Active
                   </Badge>
                 </div>

--- a/client/src/components/ui/theme-toggle.tsx
+++ b/client/src/components/ui/theme-toggle.tsx
@@ -1,18 +1,13 @@
-import React, { useState, useEffect } from 'react';
 import { Moon, Sun } from 'lucide-react';
+import { useEffect, useState } from 'react';
 import { Button } from './button';
 
 export const ThemeToggle = () => {
   const [theme, setTheme] = useState<'light' | 'dark'>('light');
 
   useEffect(() => {
-    const storedTheme = localStorage.getItem('theme') as
-      | 'light'
-      | 'dark'
-      | null;
-    const prefersDark = window.matchMedia(
-      '(prefers-color-scheme: dark)'
-    ).matches;
+    const storedTheme = localStorage.getItem('theme') as 'light' | 'dark' | null;
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
 
     const initialTheme = storedTheme || (prefersDark ? 'dark' : 'light');
     setTheme(initialTheme);
@@ -45,11 +40,7 @@ export const ThemeToggle = () => {
       className="h-9 w-9 p-0"
       aria-label="Toggle theme"
     >
-      {theme === 'light' ? (
-        <Moon className="h-4 w-4" />
-      ) : (
-        <Sun className="h-4 w-4" />
-      )}
+      {theme === 'light' ? <Moon className="h-4 w-4" /> : <Sun className="h-4 w-4" />}
     </Button>
   );
 };

--- a/client/src/components/ui/user-avatar.tsx
+++ b/client/src/components/ui/user-avatar.tsx
@@ -1,4 +1,9 @@
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+import { useAppDispatch } from '@/redux/store';
+import { logoutThunk } from '../../redux/authSlice';
 import { Avatar, AvatarFallback, AvatarImage } from './avatar';
+import { Button } from './button';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -8,11 +13,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from './dropdown-menu';
-import { logoutThunk } from '../../redux/authSlice';
-import { useNavigate } from 'react-router-dom';
-import { toast } from 'sonner';
-import { Button } from './button';
-import { useAppDispatch } from '@/redux/store';
 
 export interface UserNavProps {
   avatarUrl?: string;
@@ -32,7 +32,7 @@ export function UserNav({
     try {
       await dispatch(logoutThunk()).unwrap();
       toast.success('Logout successful');
-    } catch (error) {
+    } catch {
       toast.error('Logout failed');
     }
   };
@@ -78,9 +78,7 @@ export function UserNav({
             <DropdownMenuLabel className="font-normal">
               <div className="flex flex-col space-y-1">
                 <p className="text-sm font-medium leading-none">{username}</p>
-                <p className="text-xs leading-none text-muted-foreground">
-                  {email}
-                </p>
+                <p className="text-xs leading-none text-muted-foreground">{email}</p>
               </div>
             </DropdownMenuLabel>
             <DropdownMenuSeparator />

--- a/client/src/helpers/shareLink.ts
+++ b/client/src/helpers/shareLink.ts
@@ -14,7 +14,7 @@ export const shareLink = async ({ title, text, url }: ShareLinkParams) => {
       await navigator.clipboard.writeText(url);
       toast.success('Link copied to clipboard');
     }
-  } catch (error) {
+  } catch {
     // User may cancel share; ignore silently
   }
 };

--- a/client/src/pages/AuthPage.tsx
+++ b/client/src/pages/AuthPage.tsx
@@ -1,20 +1,12 @@
-import { FC, useState, useEffect } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
-import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import * as z from 'zod';
+import { type FC, useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
-
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import * as z from 'zod';
+import Layout from '@/components/Layout';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   Form,
   FormControl,
@@ -23,11 +15,12 @@ import {
   FormLabel,
   FormMessage,
 } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
 import { Separator } from '@/components/ui/separator';
-import Layout from '@/components/Layout';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { loginThunk, registerThunk } from '@/redux/authSlice';
-import { RootState, useAppDispatch, useAppSelector } from '@/redux/store';
 import { apiBaseUrl } from '@/redux/common.api';
+import { type RootState, useAppDispatch, useAppSelector } from '@/redux/store';
 
 // Types
 interface LoginFormData {
@@ -70,8 +63,7 @@ const AUTH_TABS = {
 
 const AuthPage: FC = () => {
   const [activeTab, setActiveTab] = useState<string>(AUTH_TABS.LOGIN);
-  const [showResendVerification, setShowResendVerification] =
-    useState<boolean>(false);
+  const [showResendVerification, setShowResendVerification] = useState<boolean>(false);
   const [lastAttemptedEmail, setLastAttemptedEmail] = useState<string>('');
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
@@ -124,7 +116,7 @@ const AuthPage: FC = () => {
           toast.error(errorMessage);
         }
       }
-    } catch (error) {
+    } catch {
       toast.error('Something went wrong during login');
     }
   };
@@ -134,15 +126,13 @@ const AuthPage: FC = () => {
       const { confirmPassword, ...registerData } = data;
       const result = await dispatch(registerThunk(registerData));
       if (result.meta.requestStatus === 'fulfilled') {
-        toast.success(
-          'Registration successful! Please check your email to verify your account.'
-        );
+        toast.success('Registration successful! Please check your email to verify your account.');
         setActiveTab(AUTH_TABS.LOGIN);
         registerForm.reset();
       } else {
         toast.error((result.payload as string) || 'Registration failed');
       }
-    } catch (error) {
+    } catch {
       toast.error('Something went wrong during registration');
     }
   };
@@ -175,7 +165,7 @@ const AuthPage: FC = () => {
         const error = await response.json();
         toast.error(error.error || 'Failed to send verification email');
       }
-    } catch (error) {
+    } catch {
       toast.error('Failed to send verification email');
     }
   };
@@ -191,11 +181,7 @@ const AuthPage: FC = () => {
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <Tabs
-              value={activeTab}
-              onValueChange={setActiveTab}
-              className="w-full"
-            >
+            <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
               <TabsList className="grid w-full grid-cols-2">
                 <TabsTrigger value={AUTH_TABS.LOGIN}>Sign In</TabsTrigger>
                 <TabsTrigger value={AUTH_TABS.REGISTER}>Sign Up</TabsTrigger>
@@ -204,10 +190,7 @@ const AuthPage: FC = () => {
               {/* Login Tab */}
               <TabsContent value={AUTH_TABS.LOGIN} className="space-y-4">
                 <Form {...loginForm}>
-                  <form
-                    onSubmit={loginForm.handleSubmit(handleLogin)}
-                    className="space-y-4"
-                  >
+                  <form onSubmit={loginForm.handleSubmit(handleLogin)} className="space-y-4">
                     <FormField
                       control={loginForm.control}
                       name="username"
@@ -243,11 +226,7 @@ const AuthPage: FC = () => {
                         </FormItem>
                       )}
                     />
-                    <Button
-                      type="submit"
-                      className="w-full"
-                      disabled={isLoading}
-                    >
+                    <Button type="submit" className="w-full" disabled={isLoading}>
                       {isLoading ? 'Signing in...' : 'Sign In'}
                     </Button>
                   </form>
@@ -286,7 +265,12 @@ const AuthPage: FC = () => {
                   onClick={handleGoogleLogin}
                   disabled={isLoading}
                 >
-                  <svg className="w-4 h-4 mr-2" viewBox="0 0 24 24">
+                  <svg
+                    className="w-4 h-4 mr-2"
+                    viewBox="0 0 24 24"
+                    aria-hidden={true}
+                    focusable={false}
+                  >
                     <path
                       fill="#4285F4"
                       d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
@@ -311,10 +295,7 @@ const AuthPage: FC = () => {
               {/* Register Tab */}
               <TabsContent value={AUTH_TABS.REGISTER} className="space-y-4">
                 <Form {...registerForm}>
-                  <form
-                    onSubmit={registerForm.handleSubmit(handleRegister)}
-                    className="space-y-4"
-                  >
+                  <form onSubmit={registerForm.handleSubmit(handleRegister)} className="space-y-4">
                     <FormField
                       control={registerForm.control}
                       name="username"
@@ -396,11 +377,7 @@ const AuthPage: FC = () => {
                         Privacy Policy
                       </span>
                     </div>
-                    <Button
-                      type="submit"
-                      className="w-full"
-                      disabled={isLoading}
-                    >
+                    <Button type="submit" className="w-full" disabled={isLoading}>
                       {isLoading ? 'Creating account...' : 'Create Account'}
                     </Button>
                   </form>

--- a/client/src/pages/ShelfSpace.tsx
+++ b/client/src/pages/ShelfSpace.tsx
@@ -1,23 +1,18 @@
 import { useSelector } from 'react-redux';
-import Layout from '../components/Layout';
-import { RootState } from '@/redux/store';
 import { toast } from 'sonner';
 import {
-  useDeleteMessageMutation,
-  useGetAllMessagesQuery,
-} from '../redux/services/messages.api';
-import {
-  ShelfSpaceHeader,
   ErrorState,
-  MessagesList,
   FormSidebar,
   LoadingState,
+  MessagesList,
+  ShelfSpaceHeader,
 } from '@/components/shelf-space';
+import type { RootState } from '@/redux/store';
+import Layout from '../components/Layout';
+import { useDeleteMessageMutation, useGetAllMessagesQuery } from '../redux/services/messages.api';
 
 export default function ShelfSpace() {
-  const { isAdmin } = useSelector(
-    (state: RootState) => state.authSlice.user.user
-  );
+  const { isAdmin } = useSelector((state: RootState) => state.authSlice.user.user);
   const { data: messages, isLoading, isError } = useGetAllMessagesQuery();
   const [deleteMessage] = useDeleteMessageMutation();
 
@@ -25,7 +20,7 @@ export default function ShelfSpace() {
     try {
       await deleteMessage({ id: messageId }).unwrap();
       toast.success('Message deleted successfully');
-    } catch (error) {
+    } catch {
       toast.error('Failed to delete message');
     }
   };

--- a/client/src/pages/UploadNewBook.tsx
+++ b/client/src/pages/UploadNewBook.tsx
@@ -1,30 +1,22 @@
-import React, { useState, useCallback } from 'react';
+import { AlertCircle, Book, CheckCircle, FileText, Upload, X } from 'lucide-react';
+import { useCallback, useState } from 'react';
 import { useDropzone } from 'react-dropzone';
-import {
-  Upload,
-  FileText,
-  X,
-  CheckCircle,
-  AlertCircle,
-  Book,
-} from 'lucide-react';
 import { toast } from 'sonner';
-
-import Layout from '../components/Layout';
-import { useAppSelector } from '@/redux/store';
-import { useAddNewBookMutation } from '../redux/services/book.api';
 import {
+  Alert,
+  AlertDescription,
+  Badge,
+  Button,
   Card,
   CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
-  Button,
   Progress,
-  Badge,
-  Alert,
-  AlertDescription,
 } from '@/components/ui';
+import { useAppSelector } from '@/redux/store';
+import Layout from '../components/Layout';
+import { useAddNewBookMutation } from '../redux/services/book.api';
 
 interface UploadFile {
   file: File;
@@ -45,13 +37,10 @@ export default function UploadNewBook() {
     formData.append('file', file);
     formData.append('upload_preset', 'unsigned_upload'); // You may need to configure this
 
-    const response = await fetch(
-      import.meta.env.VITE_CLOUDINARY_URL as string,
-      {
-        method: 'POST',
-        body: formData,
-      }
-    );
+    const response = await fetch(import.meta.env.VITE_CLOUDINARY_URL as string, {
+      method: 'POST',
+      body: formData,
+    });
 
     if (!response.ok) {
       throw new Error('Upload failed');
@@ -76,18 +65,14 @@ export default function UploadNewBook() {
     try {
       // Update status to uploading
       setUploadFiles((prev) =>
-        prev.map((f) =>
-          f.id === fileItem.id ? { ...f, status: 'uploading', progress: 0 } : f
-        )
+        prev.map((f) => (f.id === fileItem.id ? { ...f, status: 'uploading', progress: 0 } : f))
       );
 
       // Simulate progress (you can implement real progress tracking)
       const progressInterval = setInterval(() => {
         setUploadFiles((prev) =>
           prev.map((f) =>
-            f.id === fileItem.id && f.progress < 90
-              ? { ...f, progress: f.progress + 10 }
-              : f
+            f.id === fileItem.id && f.progress < 90 ? { ...f, progress: f.progress + 10 } : f
           )
         );
       }, 200);
@@ -102,22 +87,15 @@ export default function UploadNewBook() {
 
       // Update status to success
       setUploadFiles((prev) =>
-        prev.map((f) =>
-          f.id === fileItem.id ? { ...f, status: 'success', progress: 100 } : f
-        )
+        prev.map((f) => (f.id === fileItem.id ? { ...f, status: 'success', progress: 100 } : f))
       );
 
       toast.success(`${book.name} has been uploaded successfully!`);
     } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : 'Upload failed';
+      const errorMessage = error instanceof Error ? error.message : 'Upload failed';
 
       setUploadFiles((prev) =>
-        prev.map((f) =>
-          f.id === fileItem.id
-            ? { ...f, status: 'error', error: errorMessage }
-            : f
-        )
+        prev.map((f) => (f.id === fileItem.id ? { ...f, status: 'error', error: errorMessage } : f))
       );
 
       toast.error(`Upload failed: ${errorMessage}`);
@@ -157,7 +135,7 @@ export default function UploadNewBook() {
     const k = 1024;
     const sizes = ['Bytes', 'KB', 'MB', 'GB'];
     const i = Math.floor(Math.log(bytes) / Math.log(k));
-    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+    return parseFloat((bytes / k ** i).toFixed(2)) + ' ' + sizes[i];
   };
 
   const getStatusIcon = (status: UploadFile['status']) => {
@@ -209,9 +187,7 @@ export default function UploadNewBook() {
                 <Book className="h-5 w-5" />
                 Select Files
               </CardTitle>
-              <CardDescription>
-                Drag and drop your books here, or click to browse
-              </CardDescription>
+              <CardDescription>Drag and drop your books here, or click to browse</CardDescription>
             </CardHeader>
             <CardContent>
               <div
@@ -231,9 +207,7 @@ export default function UploadNewBook() {
                     <Upload className="h-8 w-8 text-primary" />
                   </div>
                   {isDragActive ? (
-                    <p className="text-lg font-medium text-primary">
-                      Drop your books here!
-                    </p>
+                    <p className="text-lg font-medium text-primary">Drop your books here!</p>
                   ) : (
                     <>
                       <p className="text-lg font-medium text-gray-900 dark:text-gray-100">
@@ -255,15 +229,14 @@ export default function UploadNewBook() {
                 <Alert>
                   <FileText className="h-4 w-4" />
                   <AlertDescription>
-                    <strong>PDF files:</strong> Perfect for academic papers,
-                    textbooks, and documents
+                    <strong>PDF files:</strong> Perfect for academic papers, textbooks, and
+                    documents
                   </AlertDescription>
                 </Alert>
                 <Alert>
                   <Book className="h-4 w-4" />
                   <AlertDescription>
-                    <strong>EPUB files:</strong> Ideal for novels, stories, and
-                    reflowable content
+                    <strong>EPUB files:</strong> Ideal for novels, stories, and reflowable content
                   </AlertDescription>
                 </Alert>
               </div>
@@ -277,8 +250,7 @@ export default function UploadNewBook() {
                 <div>
                   <CardTitle>Upload Queue</CardTitle>
                   <CardDescription>
-                    {completedFiles.length} of {uploadFiles.length} files
-                    uploaded
+                    {completedFiles.length} of {uploadFiles.length} files uploaded
                   </CardDescription>
                 </div>
                 {pendingFiles.length > 0 && (
@@ -294,9 +266,7 @@ export default function UploadNewBook() {
                       key={fileItem.id}
                       className="flex items-center space-x-4 p-4 border border-gray-200 dark:border-gray-700 rounded-lg"
                     >
-                      <div className="flex-shrink-0">
-                        {getStatusIcon(fileItem.status)}
-                      </div>
+                      <div className="flex-shrink-0">{getStatusIcon(fileItem.status)}</div>
 
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center justify-between mb-1">
@@ -308,20 +278,14 @@ export default function UploadNewBook() {
                               {formatFileSize(fileItem.file.size)}
                             </Badge>
                             <Badge variant="secondary" className="text-xs">
-                              {fileItem.file.name
-                                .split('.')
-                                .pop()
-                                ?.toUpperCase()}
+                              {fileItem.file.name.split('.').pop()?.toUpperCase()}
                             </Badge>
                           </div>
                         </div>
 
                         {fileItem.status === 'uploading' && (
                           <div className="space-y-2">
-                            <Progress
-                              value={fileItem.progress}
-                              className="h-2"
-                            />
+                            <Progress value={fileItem.progress} className="h-2" />
                             <p className="text-xs text-gray-500">
                               Uploading... {fileItem.progress}%
                             </p>
@@ -329,9 +293,7 @@ export default function UploadNewBook() {
                         )}
 
                         {fileItem.status === 'error' && (
-                          <p className="text-xs text-red-500">
-                            Error: {fileItem.error}
-                          </p>
+                          <p className="text-xs text-red-500">Error: {fileItem.error}</p>
                         )}
 
                         {fileItem.status === 'success' && (


### PR DESCRIPTION
## Summary
- remove two unused React imports and seven unused catch bindings
- apply Biome formatting, import organization, and safe type-import fixes only to the seven touched files
- mark the decorative Google logo SVG as hidden from assistive technology
- preserve application behavior, API calls, routing, UI text, and the unrelated App.tsx stash

## Verification
- `npm run check:write` and `npm run check` — passed
- targeted `noUnusedImports`, `noUnusedVariables`, and `noSvgWithoutTitle` diagnostics — zero
- client Node 20: 2 unit files / 9 tests passed
- client TypeScript and Vite production build passed
- Playwright Chromium: 3/3 smoke tests passed with no retries
- `git diff --check`

## Risks
Low. The functional edits only remove unused bindings and add decorative SVG metadata. Most of the diff is required Biome formatting/import organization in touched files.

## Follow-ups
- continue incremental Biome cleanup under #328
- UploadNewBook's two existing `noExplicitAny` warnings and one style info remain out of scope

Closes #331