### PR TITLE
fix: remove unused backend imports

### DIFF
--- a/backend/app.ts
+++ b/backend/app.ts
@@ -1,21 +1,18 @@
-import { Request, Response } from 'express';
+import type { Request, Response } from 'express';
 import 'express-async-errors';
 import cookieParser from 'cookie-parser';
-import morgan from 'morgan';
-
-import routes from './routes';
-import { json } from 'body-parser';
-
-import express from 'express';
 import cors from 'cors';
+import express from 'express';
+import morgan from 'morgan';
 import path from 'path';
-import { NotFoundError } from './errors/not-found-error';
-import { errorHandler } from './middleware/error-handler';
-import { updateMetrics } from './metrics';
-import { logger } from './logger';
 import winston from 'winston';
-import passport from './src/config/passport';
+import { NotFoundError } from './errors/not-found-error';
+import { logger } from './logger';
+import { updateMetrics } from './metrics';
+import { errorHandler } from './middleware/error-handler';
 import { Books } from './models/Books';
+import routes from './routes';
+import passport from './src/config/passport';
 
 const app = express();
 app.set('trust proxy', true);
@@ -37,13 +34,7 @@ app.use(
       'https://kitapkurdu.onrender.com',
       'https://kitap-kurdu-bx87.vercel.app',
     ],
-    allowedHeaders: [
-      'Content-Type',
-      'Authorization',
-      'X-Requested-With',
-      'Accept',
-      'Origin',
-    ],
+    allowedHeaders: ['Content-Type', 'Authorization', 'X-Requested-With', 'Accept', 'Origin'],
     credentials: true,
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
   })
@@ -67,8 +58,7 @@ app.get('/og/book/:id', async (req: Request, res: Response) => {
       : book.imageLinks?.thumbnail || `${origin}/logo-white.svg`;
 
     const title = `${book.name} | Book-Worm`;
-    const description =
-      book.description || 'Read and download books on Book-Worm';
+    const description = book.description || 'Read and download books on Book-Worm';
 
     const html = `<!DOCTYPE html>
     <html lang="en">
@@ -98,7 +88,7 @@ app.get('/og/book/:id', async (req: Request, res: Response) => {
   } catch (error) {
     logger.error('Error generating Open Graph preview', {
       bookId: req.params.id,
-      error: error instanceof Error ? error.message : 'Unknown error'
+      error: error instanceof Error ? error.message : 'Unknown error',
     });
     res.status(500).send('Server error');
   }
@@ -107,8 +97,7 @@ app.get('/og/book/:id', async (req: Request, res: Response) => {
 // Sitemap for key routes and per-book pages
 app.get('/sitemap.xml', async (req: Request, res: Response) => {
   try {
-    const origin =
-      process.env.CLIENT_URL || `${req.protocol}://${req.get('host')}`;
+    const origin = process.env.CLIENT_URL || `${req.protocol}://${req.get('host')}`;
     const staticUrls = ['/', '/all-books', '/recently-added'];
 
     const books = await Books.find({}, { _id: 1, date: 1 }).lean();
@@ -138,16 +127,14 @@ ${urls
     res.status(200).send(xml);
   } catch (error) {
     logger.error('Error generating sitemap', {
-      error: error instanceof Error ? error.message : 'Unknown error'
+      error: error instanceof Error ? error.message : 'Unknown error',
     });
     res.status(500).send('Server error');
   }
 });
 
 app.get('/healthz', (req: Request, res: Response) => {
-  res
-    .status(200)
-    .json({ status: 'ok', uptime: process.uptime(), timestamp: Date.now() });
+  res.status(200).json({ status: 'ok', uptime: process.uptime(), timestamp: Date.now() });
 });
 
 app.use(updateMetrics);
@@ -174,6 +161,7 @@ if (process.env.NODE_ENV !== 'production') {
     })
   );
 }
+
 export { app };
 
 function escapeHtml(input: string): string {

--- a/backend/controllers/books.controller.ts
+++ b/backend/controllers/books.controller.ts
@@ -1,4 +1,4 @@
-import { NextFunction, Request, Response } from 'express';
+import type { NextFunction, Request, Response } from 'express';
 import {
   addNewBook,
   deleteBook,
@@ -9,7 +9,6 @@ import {
   updateBook,
   updateCategories,
 } from '../services/book';
-import { logger } from '../logger';
 
 export const getAllBooksController = async (req: Request, res: Response, next: NextFunction) => {
   try {
@@ -55,11 +54,7 @@ export const recentlyAddedBooksController = async (
   }
 };
 
-export const deleteBookController = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
+export const deleteBookController = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const book = await deleteBook(req);
     res.status(200).json(book);

--- a/backend/routes/api/user.ts
+++ b/backend/routes/api/user.ts
@@ -1,13 +1,10 @@
-import express, { Request, Response, CookieOptions } from 'express';
+import express, { type CookieOptions, type Request, type Response } from 'express';
 import { body } from 'express-validator';
-import { auth, handlePassportAuth } from '../../middleware/auth';
-import { validateRequest } from '../../middleware/validate-request';
 import passport from 'passport';
 import {
-  generateAccessToken,
-  generateRefreshToken,
-} from '../../utils/jwt.utils';
-
+  resendVerificationController,
+  verifyEmailController,
+} from '../../controllers/emailVerification.controller';
 import {
   authController,
   loginController,
@@ -15,10 +12,10 @@ import {
   refreshTokenController,
   registerController,
 } from '../../controllers/user.controller';
-import {
-  verifyEmailController,
-  resendVerificationController,
-} from '../../controllers/emailVerification.controller';
+import { auth } from '../../middleware/auth';
+import { validateRequest } from '../../middleware/validate-request';
+import { generateAccessToken, generateRefreshToken } from '../../utils/jwt.utils';
+
 const router = express.Router();
 
 router.post(
@@ -36,15 +33,15 @@ router.post(
   '/register',
   [
     body('username', 'Please enter a valid username').isLength({ min: 3 }),
-    body('email', 'Please enter a valid email')
-      .isEmail()
-      .withMessage('Email must be valid'),
+    body('email', 'Please enter a valid email').isEmail().withMessage('Email must be valid'),
     body('password', 'Please enter a valid password')
       .trim()
       .isLength({ min: 8 })
       .withMessage('Password must be at least 8 characters')
       .matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/)
-      .withMessage('Password must contain at least one lowercase letter, one uppercase letter, and one number'),
+      .withMessage(
+        'Password must contain at least one lowercase letter, one uppercase letter, and one number'
+      ),
     body('isAdmin', 'Please enter a valid isAdmin').isBoolean().optional(),
   ],
   validateRequest,
@@ -119,11 +116,7 @@ router.post(
 router.get('/verify-email/:token', verifyEmailController);
 router.post(
   '/resend-verification',
-  [
-    body('email', 'Please enter a valid email')
-      .isEmail()
-      .withMessage('Email must be valid'),
-  ],
+  [body('email', 'Please enter a valid email').isEmail().withMessage('Email must be valid')],
   validateRequest,
   resendVerificationController
 );


### PR DESCRIPTION
## Summary
- remove three unused backend imports from the Express app, books controller, and user routes
- apply Biome formatting, import organization, and safe type-import fixes only to the three touched files
- preserve middleware order, route registration, controller behavior, and API contracts

## Verification
- `npm run check:write` and `npm run check` — passed
- targeted backend `noUnusedImports` diagnostics — zero
- backend Node 20.18.0 TypeScript build passed
- backend Jest/Supertest: 4 suites / 24 tests passed serially with mongodb-memory-server 7.0.3
- `git diff --check`

## Risks
Low. The functional changes only remove imports that had no references. Most of the diff is required Biome formatting and import organization in the touched files.

## Follow-ups
- continue incremental Biome cleanup under #328
- unused callback parameters and other existing warnings remain out of scope

Closes #333