### PR TITLE
docs: define ingestion policy and architecture

### DIFF
--- a/docs/adr/0001-automated-book-ingestion.md
+++ b/docs/adr/0001-automated-book-ingestion.md
@@ -1,0 +1,281 @@
+# ADR-0001: Automated book ingestion boundaries and architecture
+
+- Date: 2026-07-31
+- Status: Accepted
+- Approval: Operator accepted on 2026-07-31
+- Decision owners: Operator and maintainers
+- Policy: [Book ingestion sources policy](../policies/book-ingestion-sources.md)
+- Current architecture: [Repository Architecture](../architecture.md)
+- Repository instructions: [AGENTS.md](../../AGENTS.md)
+- Epic: [#345](https://github.com/sayinmehmet47/kitapKurdu/issues/345)
+- Child issue: [#347](https://github.com/sayinmehmet47/kitapKurdu/issues/347)
+- Dependency: [#344](https://github.com/sayinmehmet47/kitapKurdu/issues/344)
+
+## Context
+
+The proposed ingestion work belongs to epic [#345](https://github.com/sayinmehmet47/kitapKurdu/issues/345), with this policy and architecture decision in child issue [#347](https://github.com/sayinmehmet47/kitapKurdu/issues/347) and the data-model dependency in [#344](https://github.com/sayinmehmet47/kitapKurdu/issues/344). The [current architecture document](../architecture.md) describes the system that exists today, not this proposal.
+
+The current `Books` model lacks the fields needed for a safe ingestion workflow:
+ISBN, source identity, lifecycle status, deterministic deduplication keys, and
+an audit trail. The existing in-process Render cron is also unreliable when the
+free service is asleep. Scheduling discovery inside the web process would make
+availability, retries, and evidence dependent on a sleeping application
+instance.
+
+The current `scrapper-books` repository is a GUI/macOS/Puppeteer tool with
+untrusted-source downloader behavior. It is not an approved catalog adapter and
+must not be integrated as-is. The collector needs a substantial refactor before
+it can participate in ingestion.
+
+This ADR is paired with the [book ingestion sources policy](../policies/book-ingestion-sources.md),
+which defines allowlisted providers, evidence, moderation, links, and the
+external-link-only boundary. Both documents are accepted as the governing
+boundaries for the planned work.
+
+## Decision summary
+
+Use a scheduled, untrusted collector for discovery and a backend-owned,
+moderated workflow for admission and publication. The proposed architecture is:
+
+```text
+[Daily GitHub Actions schedule, UTC]
+                    |
+                    v
+[Refactored `scrapper-books` collector]
+  HTTP catalog adapters; structured JSON; metadata and evidence only
+                    |
+                    v
+[Approved catalog API]
+                    |
+                    v
+[Authenticated internal kitapKurdu ingestion endpoint]
+                    |
+                    v
+[Validation + rights evidence]
+                    |
+                    v
+[Atomic deduplication + daily quota]
+                    |
+                    v
+[`pending-review`]
+                    |
+                    v
+[Admin decision: approved or rejected]
+                    |
+                    v
+[Books publication]
+```
+
+The scraper repository is retained, but it is substantially refactored to use
+HTTP catalog adapters and structured JSON. The refactor removes Puppeteer,
+Brave, stealth behavior, local JSON deduplication, and file downloads. The
+backend remains the source of truth and treats every collector field as
+untrusted input requiring schema, source, rights-evidence, and moderation
+validation.
+
+Open Library is the first adapter, subject to the constraints in the [source
+policy](../policies/book-ingestion-sources.md): official metadata/search APIs,
+identified requests, caching, an initial conservative limit of no more than one
+request per second, no HTML scraping or bulk API harvesting, stable OL/IA IDs,
+`ebook_access: public`, and `public_scan_b: true`. Borrow-only and CDL items are
+denied, and only canonical OL or `archive.org/details/<id>` landing links are
+retained. Project Gutenberg is a later English public-domain adapter using its
+official feeds, catalogs, and robot rules. This ADR is accepted, but no live
+crawler may run before the relevant adapter gate is approved.
+
+## Trust boundary and conceptual API
+
+The internal ingestion endpoint is a conceptual boundary for later work; this
+ADR does not implement it. The contract must include:
+
+- HTTPS transport and server-side authentication.
+- The server-only environment-variable name `INGESTION_API_KEY`; this document
+  contains no key value. The key must never be exposed to Vite or any client
+  bundle.
+- A strict body schema, field validation, content-type checks, and request-size
+  limits.
+- A collector timestamp, unique request ID, freshness checks, and replay
+  protection.
+- Provider and host allowlists enforced by the backend, not by collector claims.
+- Endpoint and provider rate limits, bounded retries, and backoff.
+- Structured logs and audit events that redact credentials, authorization
+  headers, tokens, and other sensitive values.
+
+The endpoint accepts candidate metadata and evidence; it does not fetch a URL
+provided in the request. A successful request means only that an untrusted
+candidate was accepted for backend validation, not that it is rights-cleared or
+published.
+
+## Candidate, status, and audit model
+
+The conceptual candidate record contains provider and native IDs, normalized
+metadata, canonical link data, observed license/access signals, jurisdiction,
+terms/policy URL and observation time, collector version, deduplication keys,
+current status, and state timestamps. The audit record is append-only and
+records the event, decision or reason, actor/role, request ID where applicable,
+and timestamp. Rejected and duplicate candidates are retained as decisions,
+not silently discarded.
+
+The workflow is:
+
+```text
+submitted -> validating -> duplicate
+                      \-> pending-review -> approved -> published
+                                         \-> rejected
+```
+
+Publication is a separate, idempotent operation. It maps approved metadata into
+`Books` only after the fields and indexes from [#344](https://github.com/sayinmehmet47/kitapKurdu/issues/344)
+exist. A takedown or later rights concern can move a published entry to an
+unpublished/blocked state without deleting its audit history.
+
+### Backend-owned deterministic deduplication
+
+The backend, not the collector, owns deduplication. The keys are evaluated in
+this order of trust and availability:
+
+- A required normalized `provider + native ID` key. A candidate without a
+  stable provider-native identity cannot pass admission.
+- A normalized ISBN-13 key when an ISBN is available.
+- A hash of a normalized canonical URL, without fetching that URL.
+- A content SHA-256 only if a future, separately accepted mirroring ADR permits
+  fetching content. It is not available in this external-link-only MVP.
+- Normalized title + authors + language as a potential-duplicate review signal
+  only. It is not a deterministic identity and must not reject or merge by
+  itself.
+
+Database unique constraints and an atomic upsert enforce the authoritative keys.
+MongoDB `E11000` duplicate-key results are classified as duplicate decisions,
+not generic failures. Retries and replayed requests must be idempotent and must
+not create another candidate or consume another quota slot.
+
+### Daily quota
+
+The quota is exactly the policy limit: at most **10 newly accepted unique
+`pending-review` candidates per UTC day**. Duplicate and rejected candidates are
+audited but do not consume the pending-review admission/publication slots. The
+ceiling is not a promise of exactly 10 and never permits auto-publication. The
+atomic quota decision belongs to the backend so concurrent requests cannot
+exceed it.
+
+## MVP link and file boundary
+
+The MVP stores metadata and a canonical external landing link only. Links are
+regenerated from native IDs rather than copied from arbitrary collector input,
+and the backend never fetches user- or provider-supplied URLs. Covers may be
+linked only when the provider's policy permits that link and use.
+
+There is no backend book-file fetch, Cloudinary copy, malware scanning, or
+quarantine in this ADR. A future mirror would require a new accepted ADR with
+explicit rights and secure fetch, redirect, DNS, storage, scanning, retention,
+and takedown controls.
+
+## Threat model
+
+| Threat | Controls | Residual risk |
+| --- | --- | --- |
+| Source rights ambiguity | Allowlisted categories; jurisdiction and observed policy evidence; unknown rights rejected or held; manual review; no auto-publication. | Evidence or a reviewer can still be wrong, and rights vary across jurisdictions and time. |
+| Malicious payload or schema | Strict schema and types; size/content-type limits; untrusted-input validation; no execution of submitted fields; isolated tests. | Parser or validation defects may admit unexpected data. |
+| SSRF, DNS rebinding, or redirects | Not reachable in the MVP because the backend performs no URL fetch; any future fetch must use URL/host allowlists, safe DNS/IP checks, redirect limits, egress controls, timeouts, and revalidation. | A future mirroring implementation could reintroduce network risk if those controls are incomplete. |
+| Oversized requests | Body and field size limits, rate limiting, bounded retries, and request metrics. | Distributed abuse or provider-side limits can still cause resource pressure. |
+| Duplicate races or replay | Backend-owned normalized keys; database unique constraints; atomic upsert/quota operations; timestamps, request IDs, replay checks; `E11000` classification. | Operational recovery or a database outage may require reconciliation. |
+| Credential leakage | Server-only `INGESTION_API_KEY` name; never expose secrets to Vite/client; redact headers/tokens from logs and audit fields; least-privilege access. | Misconfiguration outside the application or an unredacted operational tool may still leak a credential. |
+| Catalog poisoning or metadata spoofing | Provider/host allowlists; native-ID validation; source evidence snapshots; cross-field validation; manual review; backend source of truth. | An approved catalog can contain inaccurate, compromised, or disputed metadata. |
+| Dependency or supply-chain compromise | Minimal collector dependencies; review and update process; fixture-only tests; least-privilege CI/runtime permissions; observable versioned collectors. | A compromised dependency or upstream build can still produce malicious input. |
+| Provider outage or rate limit | Official APIs/feeds; identified requests; caching; conservative rates; bounded backoff; pause-on-policy/error signals; no dependency on the web process staying awake. | Discovery can be delayed and provider availability is outside kitapKurdu's control. |
+| Link rot or takedown | Store native IDs and regenerate canonical links; provider-policy review; report/takedown workflow; immediate unpublish capability; retained audit. | An external link can change or disappear between reviews. |
+| Accidental auto-publication | Explicit status machine; separate idempotent publication operation; admin decision required; collector has no publish path; quota and state-transition tests. | A future code or operational mistake could bypass a control, so monitoring and review remain necessary. |
+
+## Testing and observability expectations
+
+Later implementation children must provide:
+
+- Fixture-only adapter tests with no production or external calls.
+- In-memory MongoDB integration tests covering concurrent duplicates and
+  concurrent daily-quota admission.
+- Contract tests for the collector payload and internal endpoint.
+- Admin E2E tests using a mocked API and deterministic candidate fixtures.
+- Counters and job audits for submissions, validation outcomes, duplicates,
+  quota decisions, moderation, publication, errors, retries, and takedowns,
+  without credentials or other sensitive values.
+
+Observability must make provider, adapter version, status, request/job ID, and
+reason visible without logging authentication material or book-file contents.
+
+## Consequences
+
+### Advantages
+
+- Rights decisions are explicit, jurisdiction-aware, and reviewable.
+- The web service is not the scheduler, so Render sleep/cold-start behavior does
+  not silently erase daily collection work.
+- Backend-owned identity, quota, and publication reduce duplicate and replay
+  risk.
+- External links avoid storing untrusted book files and reduce free-tier,
+  malware, takedown, and storage exposure.
+- Provider-specific rules are visible and can be paused without weakening the
+  general moderation boundary.
+
+### Tradeoffs
+
+- Manual review limits throughput and creates an administrative workload.
+- External links can rot, vary by country, or become unavailable without a
+  local fallback.
+- The first release cannot offer offline reading, local file scanning, or a
+  controlled mirror.
+- More schema, indexes, endpoint, audit, and moderation work is required before
+  the existing `Books` publication path can be used.
+- Provider policy changes and regional rights differences require ongoing review;
+  this architecture makes no legal guarantee.
+
+## Rejected alternatives
+
+- **Integrate the current scraper as-is:** Its GUI/macOS/Puppeteer, stealth, and
+  untrusted downloader behavior do not provide a controlled server-side trust
+  boundary.
+- **Backend in-process cron:** Render sleep and process restarts make it an
+  unreliable scheduler and mix discovery with web availability.
+- **Title-only/local JSON dedup:** It is non-deterministic, not shared by
+  workers, vulnerable to races, and cannot support replay-safe publication.
+- **Automatic publication:** Provider flags and metadata are not a substitute
+  for rights evidence and human review.
+- **MVP mirroring/download:** It increases legal, malware, storage, takedown,
+  and free-tier exposure before rights and file controls exist.
+- **Scraping provider HTML:** It violates or risks provider rules, is brittle,
+  and is unnecessary when approved catalog APIs or feeds exist.
+
+## Rollout sequence
+
+1. The source policy and this ADR are accepted through operator/maintainer
+   review.
+2. Complete [#344](https://github.com/sayinmehmet47/kitapKurdu/issues/344), including
+   the metadata, source, status, deduplication, and audit fields needed by the
+   workflow.
+3. Add ingestion models and database indexes with atomic deduplication and quota
+   behavior.
+4. Add the authenticated internal ingestion endpoint and its contract,
+   validation, limits, replay protection, and redacted observability.
+5. Refactor `scrapper-books` into approved HTTP catalog adapters and structured
+   JSON, beginning with Open Library.
+6. Add admin moderation, publication, unpublish, attribution, and takedown
+   controls.
+7. Add GitHub Actions scheduling, bounded retry, counters, and job audits; only
+   then consider a new ADR for any mirroring or file-fetch capability.
+
+## Decision gates and approval boundary
+
+Operator approval is required at each gate:
+
+| Gate | Approval required |
+| --- | --- |
+| Documentation | Accepted on 2026-07-31; the policy and this ADR are the governing boundaries. |
+| Data model | The fields, indexes, status transitions, and audit retention from [#344](https://github.com/sayinmehmet47/kitapKurdu/issues/344) are reviewed before publication work. |
+| Endpoint | The conceptual trust-boundary controls are implemented and reviewed before accepting collector requests. |
+| Provider adapter | Each provider's policy, terms, evidence fields, rate behavior, and landing-link rules are reviewed before activation. |
+| Moderation/release | Admin approval, attribution, immediate unpublish, and takedown paths are tested before any candidate can be published. |
+| Mirroring | A separate ADR is accepted before any remote book-file fetch, storage copy, scanning, or quarantine is introduced. |
+
+Acceptance of this ADR and the linked policy is **documentation approval only**.
+It is not permission to scrape, download, mirror, or publish unknown-rights
+books, and it does not authorize implementation to bypass the provider rules or
+manual-review requirements in the policy.

--- a/docs/policies/book-ingestion-sources.md
+++ b/docs/policies/book-ingestion-sources.md
@@ -1,0 +1,202 @@
+# Book ingestion sources policy
+
+- Status: Accepted
+- Approval: Operator accepted on 2026-07-31
+- Owners: Operator and maintainers
+- Effective date: 2026-07-31
+- Issue: [#347](https://github.com/sayinmehmet47/kitapKurdu/issues/347)
+- Related ADR: [ADR-0001: Automated book ingestion boundaries and architecture](../adr/0001-automated-book-ingestion.md)
+
+## Purpose and scope
+
+This policy defines which book sources kitapKurdu may use and what evidence is
+required before a candidate can be considered for moderation. It governs
+discovery, metadata, links, files, moderation, publication, attribution, and
+takedown. It applies to collectors, adapters, backend ingestion, administrators,
+and any future source or mirroring feature.
+
+This policy is the source-specific companion to the [automated ingestion
+ADR](../adr/0001-automated-book-ingestion.md). It is informed by the epic
+[#345](https://github.com/sayinmehmet47/kitapKurdu/issues/345), this child issue
+[#347](https://github.com/sayinmehmet47/kitapKurdu/issues/347), and dependency
+[#344](https://github.com/sayinmehmet47/kitapKurdu/issues/344). The [current
+architecture document](../architecture.md) describes the implemented system;
+this policy and the ADR describe accepted boundaries for the planned work. Contributors
+must also follow the repository [AGENTS.md](../../AGENTS.md).
+
+This is an operational risk-control document, not legal advice and not a global
+determination of copyright status. Rights can differ by work, edition,
+jurisdiction, format, and time.
+
+## Default principles
+
+All ingestion decisions follow these principles:
+
+1. **Rights before volume.** A smaller set of well-supported candidates is
+   preferable to a larger set with uncertain rights.
+2. **External canonical links over mirroring.** Link to an authoritative
+   landing page rather than copying book files.
+3. **Metadata access is not content redistribution permission.** An API or
+   catalog may expose metadata without granting permission to redistribute the
+   underlying text, scans, or files.
+4. **Unknown rights means reject or hold.** Unclear, conflicting, or
+   jurisdictionally incomplete evidence never becomes an automatic approval.
+5. **Manual approval.** Automation may discover, normalize, validate, and
+   queue candidates; a reviewer decides whether a candidate may be published.
+6. **Least privilege and auditable evidence.** Collect only what is needed,
+   retain the observations and decisions that support each candidate, and make
+   actions attributable and reviewable.
+
+Provider indicators are evidence about what a provider reported at an observed
+time. They are not a global legal conclusion, and fields such as `public` or
+`publicDomain` must not be treated as definitive proof worldwide.
+
+## Allowlisted source categories
+
+A candidate may be considered only when its source fits one of these categories
+and the evidence is retained:
+
+- A verified public-domain source, with the relevant jurisdiction recorded.
+- An explicit open license or other explicit permission that covers the
+  proposed use.
+- Approval from the author or rightsholder, retained in a reviewable form.
+- An explicitly authorized link to an authoritative catalog or landing page,
+  when the use is limited to that link and the catalog's access terms permit
+  it.
+
+Being discoverable, free to read, searchable, previewable, borrowable, or
+available through an API does not by itself satisfy one of these categories.
+
+### Required evidence for every candidate
+
+The system must retain these fields for every candidate, including candidates
+that are rejected or deduplicated:
+
+| Evidence field | Requirement |
+| --- | --- |
+| Provider | The named provider and adapter that supplied the observation. |
+| Native source IDs | Stable identifiers supplied by the provider, such as an Open Library or Internet Archive ID. |
+| Canonical URL | The provider-approved landing URL; arbitrary deep file URLs are not acceptable for the MVP. |
+| Observed license/access signals | The raw or faithfully represented license, access, availability, and relevant provider flags observed by the collector. |
+| Jurisdiction | The country or other jurisdiction to which a rights or access statement applies; unknown must be recorded as unknown rather than inferred. |
+| Terms/policy URL and observed time | The provider terms, robot, license, or policy URL consulted and when it was observed. |
+| Collector version | The version of the collector/adapter that produced the observation. |
+| Reviewer decision, reason, and timestamps | The decision (`approved`, `rejected`, or `held`), the reason, reviewer identity or role, and decision and state-transition times. These may be pending before review. |
+
+Evidence is captured as an observation, not rewritten into a stronger claim.
+For example, a provider's access flag can support a review but cannot establish
+public-domain status in every jurisdiction.
+
+## Initial provider matrix
+
+The following matrix is the initial allowlist. “Future” means that no adapter
+may be activated until its implementation, terms review, and operator approval
+are complete.
+
+| Provider/source | State | Allowed use and constraints |
+| --- | --- | --- |
+| Open Library metadata and Search API | **Initial adapter** | Use the official metadata/search APIs only. Identify requests with an application `User-Agent` and contact information, cache responses, and begin at a conservative rate of no more than 1 request per second. Do not scrape HTML or harvest the API in bulk. Only candidates with `ebook_access: public`, `public_scan_b: true`, and stable Open Library and/or Internet Archive IDs may enter manual review. Borrow-only and controlled-digital-lending (CDL) items are denied. Store the canonical Open Library landing page or an `archive.org/details/<id>` landing link, never an arbitrary deep file URL. |
+| Project Gutenberg | **Future English public-domain adapter** | Use official feeds, catalog data, and the provider's robot-harvest rules. Apply the US-only public-domain caveat; an item reported as public domain in the United States is not automatically public domain elsewhere. Use ebook landing pages only. Do not use prohibited deep links or general website crawling. |
+| Google Books | **Metadata enrichment only** | Use the Books API for metadata enrichment and a canonical volume reference when appropriate. Country-scoped access and `publicDomain` fields are evidence only and are not sole rights proof. Download URLs, ACS/token URLs, and other content acquisition links are denied. |
+| Standard Ebooks | **Future adapter** | Activation depends on permitted feed access and current terms. Record the explicit license/public-domain evidence applicable to the specific Standard Ebooks work and its jurisdictional limits. |
+| Welib, Library Genesis, Z-Library, Anna's Archive mirrors, private groups, and unknown mirrors | **Not allowlisted** | Do not discover, collect, link, download, or publish candidates from these sources. A mirror's claim, availability, or popularity is not an allowlist decision. |
+| Current live behavior of `scrapper-books` | **Not allowlisted** | The current GUI/macOS/Puppeteer and untrusted-source downloader behavior is not an approved provider or adapter. It must not be integrated as-is; see the [ADR](../adr/0001-automated-book-ingestion.md). |
+
+Provider status is not permanent. A future adapter needs a policy and terms
+review before activation, and a material provider-policy change pauses the
+adapter until the evidence is reassessed.
+
+## Prohibited behavior
+
+The following are prohibited under this policy:
+
+- Bypassing DRM or paywalls.
+- Evading anti-bot controls, rate limits, blocks, or provider detection through
+  stealth techniques.
+- Scraping private groups or using credentials obtained for a private group.
+- Automatically publishing or downloading a book when rights are unknown.
+- Downloading borrow-only, CDL, licensed-preview, or otherwise access-limited
+  content as though it were freely redistributable.
+- Collecting provider or user credentials.
+- Unauthorized mirroring or copying of provider-hosted book files.
+- Bypassing, delaying, or concealing a takedown or unpublish decision.
+
+## MVP boundary: external links only
+
+The MVP is **external-link-only**. It may retain reviewed metadata and an
+approved canonical landing link, but it must not fetch remote book files. The
+MVP therefore includes no remote book-file fetch, Cloudinary copy, malware
+scanning, or quarantine pipeline yet. This keeps Render, MongoDB Atlas, and
+Cloudinary free-tier resource use predictable and limits the legal and security
+exposure of handling untrusted files.
+
+Any future mirroring must be proposed in and approved through a new ADR. That
+ADR must provide secure fetch controls, explicit rights for the exact use and
+jurisdiction, provider-compliant access, file-handling controls, and an
+operator-approved migration plan. This policy does not grant permission to add
+those capabilities.
+
+## Moderation, publication, attribution, and takedown
+
+Automation may create a `pending-review` candidate only after the required
+evidence, validation, deduplication, and quota checks succeed. A human reviewer
+must record an approval or rejection and the reason. No collector, cron job, or
+API request may publish directly.
+
+Published entries must attribute the source in a clear, non-misleading way.
+Attribution should identify the provider, relevant author/title metadata,
+canonical landing link, applicable license or permission evidence, and
+jurisdiction where useful. Attribution must not imply that a provider endorses
+kitapKurdu or that a provider flag is a universal rights determination.
+
+Reports from a rightsholder, provider, user, or other credible reporter must be
+logged with the received time, affected candidate, report reason, and actions.
+The expected response is:
+
+1. Immediately unpublish or hide the affected entry and disable its external
+   link when a credible takedown or rights concern is received.
+2. Preserve the audit record and evidence; do not erase history to make the
+   entry appear never to have existed.
+3. Mark the candidate as blocked or under takedown review, stop related
+   automation, and investigate the source, jurisdiction, and permission.
+4. Communicate with the reporter or provider when appropriate and record the
+   outcome.
+5. Republish only after a fresh manual decision with current evidence.
+
+Evidence, moderation decisions, publication changes, provider-policy reviews,
+and takedown events are append-only audit events. Retain them for the life of
+the candidate/publication and for at least 12 months after rejection or
+takedown, unless a longer operational or legal retention requirement applies.
+Retention must not be used to retain secret values or unnecessary credentials.
+
+Maintainers review each active provider's terms, robot rules, licenses, and
+access signals at least quarterly and before activating a new adapter. A
+material change, block, policy notice, rights report, or unexplained access
+change pauses the affected adapter; the change and the response must be
+recorded before collection resumes.
+
+## Daily candidate semantics
+
+At most **10 newly accepted unique `pending-review` candidates per UTC day**
+may pass validation, deduplication, and quota admission. This is a ceiling, not
+a promise of exactly 10, and no candidate is auto-published. A provider may
+produce zero candidates, and a day may end below the ceiling for rights,
+quality, availability, or operational reasons.
+
+Duplicates and rejected candidates do not consume the 10-candidate
+pending-review admission/publication slots, but their observations and
+decisions remain audited. Quota accounting must be atomic and backend-owned so
+retries and concurrent collectors cannot create more than the daily limit.
+
+## Official references
+
+The following official references were fetched on 2026-07-31. They inform
+provider handling but do not replace candidate-level rights review:
+
+- Open Library [APIs](https://openlibrary.org/developers/api), [Search API](https://openlibrary.org/dev/docs/api/search), [licensing](https://openlibrary.org/developers/licensing), and [borrowing FAQ](https://openlibrary.org/help/faq/borrow).
+- Project Gutenberg [robot access](https://www.gutenberg.org/policy/robot_access.html), [permissions](https://www.gutenberg.org/policy/permission.html), and [terms of use](https://www.gutenberg.org/policy/terms_of_use.html).
+- Google Books [using the API](https://developers.google.com/books/docs/v1/using) and [Volume reference](https://developers.google.com/books/docs/v1/reference/volumes).
+- Standard Ebooks [feeds](https://standardebooks.org/feeds) and [about](https://standardebooks.org/about).
+
+Provider pages and terms can change. The observed URL and time must therefore
+be retained with each candidate and revisited under the review cadence above.


### PR DESCRIPTION
## Summary
- define allowlisted book-ingestion source and license rules
- record the external-link-only ingestion architecture and moderation workflow
- document deterministic deduplication, daily quota, threat controls, and the scrapper-books refactor boundary

## Verification
- validated all relative documentation links
- confirmed all cited provider documentation URLs resolve
- `git diff --check` passes
- documentation-only diff; builds are not required

## Risks
- provider rights signals remain jurisdiction-specific and require manual review
- implementation remains gated by structured metadata issue #344

## Follow-up
- implement #344 before adding ingestion models or adapters

Closes #347
