### PR TITLE
fix: support partial legacy author search

### DIFF
--- a/backend/routes/api/__test__/books.test.ts
+++ b/backend/routes/api/__test__/books.test.ts
@@ -195,6 +195,46 @@ it('searches metadata and keywords with AND filters', async () => {
       url: DUMMY_PDF_URL,
       size: 100,
     },
+    {
+      name: 'Türkçe Yazar',
+      author: 'Şahin Çelik',
+      url: DUMMY_PDF_URL,
+      size: 100,
+    },
+    {
+      name: 'Legacy Author - Title Only Token',
+      url: DUMMY_PDF_URL,
+      size: 100,
+    },
+    {
+      name: 'Legacy Author - Null Title',
+      author: null,
+      url: DUMMY_PDF_URL,
+      size: 100,
+    },
+    {
+      name: 'Legacy Author - Empty Title',
+      author: '',
+      url: DUMMY_PDF_URL,
+      size: 100,
+    },
+    {
+      name: 'Legacy Author - Whitespace Title',
+      author: '   ',
+      url: DUMMY_PDF_URL,
+      size: 100,
+    },
+    {
+      name: 'Legacy Prefix - Populated Title',
+      author: 'Actual Author',
+      url: DUMMY_PDF_URL,
+      size: 100,
+    },
+    {
+      name: 'Authorless title without separator',
+      url: DUMMY_PDF_URL,
+      size: 100,
+    },
   ]);
 
   const keyword = await request(app).get('/api/books/search').query({ q: 'KAYIP' }).expect(200);
@@ -204,7 +244,60 @@ it('searches metadata and keywords with AND filters', async () => {
     .get('/api/books/search')
     .query({ author: 'orhan pamuk' })
     .expect(200);
+  expect(author.body.total).toBe(1);
   expect(author.body.results[0].name).toBe('Kayıp Zaman');
+
+  const partialAuthor = await request(app)
+    .get('/api/books/search')
+    .query({ author: 'pamuk' })
+    .expect(200);
+  expect(partialAuthor.body.total).toBe(1);
+  expect(partialAuthor.body.results[0].author).toBe('Orhan Pamuk');
+
+  const normalizedAuthor = await request(app)
+    .get('/api/books/search')
+    .query({ author: 'sahin celik' })
+    .expect(200);
+  expect(normalizedAuthor.body.total).toBe(1);
+  expect(normalizedAuthor.body.results[0].name).toBe('Türkçe Yazar');
+
+  const escapedAuthor = await request(app)
+    .get('/api/books/search')
+    .query({ author: '.*' })
+    .expect(200);
+  expect(escapedAuthor.body.total).toBe(0);
+
+  const legacyAuthorFilter = await request(app)
+    .get('/api/books/search')
+    .query({ author: 'legacy' })
+    .expect(200);
+  expect(legacyAuthorFilter.body.total).toBe(4);
+  expect(legacyAuthorFilter.body.results.map((book: { name: string }) => book.name)).toEqual(
+    expect.arrayContaining([
+      'Legacy Author - Title Only Token',
+      'Legacy Author - Null Title',
+      'Legacy Author - Empty Title',
+      'Legacy Author - Whitespace Title',
+    ])
+  );
+
+  const titleOnlyAuthorFilter = await request(app)
+    .get('/api/books/search')
+    .query({ author: 'title only' })
+    .expect(200);
+  expect(titleOnlyAuthorFilter.body.total).toBe(0);
+
+  const authorlessTitleFilter = await request(app)
+    .get('/api/books/search')
+    .query({ author: 'authorless' })
+    .expect(200);
+  expect(authorlessTitleFilter.body.total).toBe(0);
+
+  const populatedPrefixAuthorFilter = await request(app)
+    .get('/api/books/search')
+    .query({ author: 'legacy prefix' })
+    .expect(200);
+  expect(populatedPrefixAuthorFilter.body.total).toBe(0);
 
   const isbn = await request(app)
     .get('/api/books/search')
@@ -241,6 +334,36 @@ it('searches metadata and keywords with AND filters', async () => {
     .query({ name: 'KAYIP' })
     .expect(200);
   expect(legacyRoute.body.results[0].name).toBe('Kayıp Zaman');
+});
+
+it('matches NFD-decomposed legacy author names with plain queries', async () => {
+  const ihsanBookName = 'I\u0307hsan Oktay Anar - Puslu Kıtalar Atlası';
+  const sahinCelikBookName = 'S\u0327ahin C\u0327elik - Kayıp Zaman';
+
+  await Books.insertMany([
+    {
+      name: ihsanBookName,
+      url: DUMMY_PDF_URL,
+      size: 100,
+    },
+    {
+      name: sahinCelikBookName,
+      url: DUMMY_PDF_URL,
+      size: 100,
+    },
+  ]);
+
+  const ihsan = await request(app).get('/api/books/search').query({ author: 'ihsan' }).expect(200);
+  expect(ihsan.body.total).toBe(1);
+  expect(ihsan.body.results[0].name).toBe(ihsanBookName);
+
+  const sahin = await request(app).get('/api/books/search').query({ author: 'sahin' }).expect(200);
+  expect(sahin.body.total).toBe(1);
+  expect(sahin.body.results[0].name).toBe(sahinCelikBookName);
+
+  const celik = await request(app).get('/api/books/search').query({ author: 'celik' }).expect(200);
+  expect(celik.body.total).toBe(1);
+  expect(celik.body.results[0].name).toBe(sahinCelikBookName);
 });
 
 it('paginates metadata searches with bounded page and limit values', async () => {

--- a/backend/services/book/searchBooks.service.ts
+++ b/backend/services/book/searchBooks.service.ts
@@ -33,18 +33,28 @@ const parseBoundedPositiveInt = (value: unknown, fallback: number, maximum: numb
 
 const escapeRegExp = (input: string): string => input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
+const turkishCharacterPatterns: Record<string, string> = {
+  i: '[ıiİI](?:\\x{0307})?',
+  ı: '[ıiİI](?:\\x{0307})?',
+  s: '[şsŞS](?:\\x{0327})?',
+  ş: '[şsŞS](?:\\x{0327})?',
+  c: '[çcÇC](?:\\x{0327})?',
+  ç: '[çcÇC](?:\\x{0327})?',
+  g: '[ğgĞG](?:\\x{0306})?',
+  ğ: '[ğgĞG](?:\\x{0306})?',
+  u: '[üuÜU](?:\\x{0308})?',
+  ü: '[üuÜU](?:\\x{0308})?',
+  o: '[öoÖO](?:\\x{0308})?',
+  ö: '[öoÖO](?:\\x{0308})?',
+};
+
 const normalizeTurkishText = (text: string): string => {
   if (!text) return '';
 
-  const escaped = escapeRegExp(text.toLocaleLowerCase('tr'));
+  const escaped = escapeRegExp(text.normalize('NFC').toLocaleLowerCase('tr'));
 
   return escaped
-    .replace(/[ıiİI]/gi, '[ıiİI]')
-    .replace(/[şs]/gi, '[şs]')
-    .replace(/[ğg]/gi, '[ğg]')
-    .replace(/[üu]/gi, '[üu]')
-    .replace(/[öo]/gi, '[öo]')
-    .replace(/[çc]/gi, '[çc]')
+    .replace(/[ıişsğgüuoöçc]/g, (character) => turkishCharacterPatterns[character])
     .replace(/\\\s+/g, '\\s*')
     .replace(/\s+/g, '\\s*');
 };
@@ -80,7 +90,33 @@ const searchBooksService = async (req: Request) => {
   }
 
   if (author) {
-    filters.push({ author });
+    const normalizedAuthor = normalizeTurkishText(author);
+    filters.push({
+      $or: [
+        { author: { $regex: normalizedAuthor, $options: 'i' } },
+        {
+          $expr: {
+            $and: [
+              {
+                $eq: [{ $trim: { input: { $ifNull: ['$author', ''] } } }, ''],
+              },
+              {
+                $gte: [{ $size: { $split: [{ $ifNull: ['$name', ''] }, ' - '] } }, 2],
+              },
+              {
+                $regexMatch: {
+                  input: {
+                    $arrayElemAt: [{ $split: [{ $ifNull: ['$name', ''] }, ' - '] }, 0],
+                  },
+                  regex: normalizedAuthor,
+                  options: 'i',
+                },
+              },
+            ],
+          },
+        },
+      ],
+    });
   }
 
   if (isbn) {

--- a/client/tests/search-to-book.spec.ts
+++ b/client/tests/search-to-book.spec.ts
@@ -103,4 +103,25 @@ test.describe('Search to book detail flow', () => {
     ).toHaveCount(1);
     await expect(ratingSummary.getByRole('radiogroup')).toHaveCount(0);
   });
+
+  test('searches books by a partial author value', async ({ page }) => {
+    await page.goto('/');
+
+    const searchRequestPromise = page.waitForRequest((request) => {
+      const url = new URL(request.url());
+      return (
+        url.pathname.endsWith('/api/books/search') && url.searchParams.get('author') === 'Author'
+      );
+    });
+
+    await page.getByLabel('Author').fill('Author');
+    await page.getByRole('button', { name: 'Search' }).click();
+
+    const searchRequest = await searchRequestPromise;
+    expect(new URL(searchRequest.url()).searchParams.get('author')).toBe('Author');
+    await expect(page.getByText('Search Results')).toBeVisible();
+    await expect(page.getByText(MOCK_BOOK_TITLE)).toBeVisible();
+    const searchResultRow = page.getByRole('row').filter({ hasText: MOCK_BOOK_TITLE });
+    await expect(searchResultRow.getByRole('cell').nth(1)).toContainText('Test Author');
+  });
 });


### PR DESCRIPTION
## Summary
- make Author filters use safe Turkish-aware partial matching
- support legacy records whose author is stored in the `Author - Title` name prefix without matching title text
- handle NFC and NFD Turkish characters used by the existing dataset
- add backend and Playwright regression coverage

## Local data diagnosis
- sampled legacy records have `author: null`; author names are embedded before ` - ` in `name`
- `author=ihsan` now returns 8 local matches, including 7 İhsan Oktay Anar titles
- `author=İhsan`, `author=sahin`, and `author=celik` match decomposed Unicode records
- title-only `author=hiyel` returns zero

## Verification
- backend `npm test`: 33 passed
- backend `npm run build`: passed
- client `npm test`: 28 passed
- client `npm run build`: passed
- client `npm run test:e2e`: 4 passed
- root `npm run check`: passed

## Database impact
- no schema, index, migration, backfill, or data mutation
- fallback is query-time only and preserves populated author fields

## Risks
- legacy fallback depends on the existing `Author - Title` naming convention
- partial author queries use a collection scan; existing 60-second cache limits repeated work

Closes #351