### PR TITLE
fix: remove personal footer attribution

### DIFF
--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -1,26 +1,8 @@
-import { FaGithub, FaLinkedin } from 'react-icons/fa';
-
 export default function Footer() {
   return (
     <footer className="border-t border-border bg-muted/30">
       <div className="container mx-auto flex flex-col items-center justify-between gap-3 px-4 py-4 text-sm text-muted-foreground sm:flex-row">
-        <p>Made with ❤️ by Mehmet Sayin</p>
-        <nav aria-label="Footer navigation" className="flex items-center gap-4">
-          <a
-            href="https://github.com/sayinmehmet47"
-            aria-label="GitHub profile"
-            className="rounded-sm hover:text-foreground"
-          >
-            <FaGithub aria-hidden="true" size={25} />
-          </a>
-          <a
-            href="https://www.linkedin.com/in/sayinmehmet/"
-            aria-label="LinkedIn profile"
-            className="rounded-sm hover:text-foreground"
-          >
-            <FaLinkedin aria-hidden="true" size={25} />
-          </a>
-        </nav>
+        <p>© KitapKurdu</p>
       </div>
     </footer>
   );

--- a/client/src/components/__tests__/Footer.test.tsx
+++ b/client/src/components/__tests__/Footer.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import Footer from '../Footer';
+
+describe('Footer', () => {
+  it('renders neutral branding without footer links', () => {
+    render(<Footer />);
+
+    const footer = screen.getByRole('contentinfo');
+
+    expect(screen.getAllByRole('contentinfo')).toHaveLength(1);
+    expect(within(footer).getByText('© KitapKurdu', { exact: true })).toBeInTheDocument();
+    expect(within(footer).queryAllByRole('link')).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- remove the operator's personal name from the public footer
- remove personal GitHub and LinkedIn profile links/icons
- keep a neutral semantic `© KitapKurdu` footer
- add a regression test for neutral branding and no footer links

## Verification
- client `npm test`: 34 passed
- client `npm run build`: passed
- client `npm run test:e2e`: 7 passed
- root `npm run check`: passed
- client source contains no removed personal attribution/profile references

## Risk
- minimal presentation-only privacy hotfix; no API, database, or deployment configuration changes

Closes #361