### PR TITLE
fix: remove uploader PII from public book APIs

### DIFF
--- a/backend/routes/api/__test__/books.test.ts
+++ b/backend/routes/api/__test__/books.test.ts
@@ -1,6 +1,7 @@
 import request from 'supertest';
 import { app } from '../../../app';
 import { Books } from '../../../models/Books';
+import { User } from '../../../models/User';
 import { fetchGoogleBooksMetadata } from '../../../services/book/googleBooksMetadata.service';
 
 jest.mock('../../../services/book/googleBooksMetadata.service');
@@ -15,7 +16,6 @@ const VALID_BOOK_DATA = {
   name: 'test',
   url: DUMMY_PDF_URL,
   size: 100,
-  uploader: 'test',
 };
 
 beforeEach(() => {
@@ -37,7 +37,7 @@ it('return 400 with invalid body', async () => {
       expect(res.body.errors[0].message).toEqual('Name is required');
       expect(res.body.errors[1].message).toEqual('Url is required');
       expect(res.body.errors[2].message).toEqual('Size is required');
-      expect(res.body.errors[3].message).toEqual('Uploader is required');
+      expect(res.body.errors).toHaveLength(3);
     });
 });
 
@@ -56,6 +56,28 @@ it('should allow authorized users to upload new book', async () => {
       uploader: sender,
     })
     .expect(201);
+});
+
+it('ignores a legacy uploader body value and stores the authenticated user', async () => {
+  const { accessToken, sender } = await global.signin();
+  const otherUser = await User.create({
+    username: 'spoof-target',
+    email: 'spoof-target@example.com',
+  });
+
+  const response = await request(app)
+    .post('/api/books/addNewBook')
+    .set('Cookie', `accessToken=${accessToken}`)
+    .send({
+      ...VALID_BOOK_DATA,
+      uploader: otherUser._id,
+    })
+    .expect(201);
+
+  const storedBook = await Books.findById(response.body._id).lean();
+
+  expect(String(response.body.uploader)).toBe(String(sender));
+  expect(String(storedBook?.uploader)).toBe(String(sender));
 });
 
 it('populates book metadata from the provider', async () => {
@@ -456,4 +478,47 @@ it('should get all books paginated', async () => {
   expect(allBooks.body.data.total).toEqual(2);
   expect(allBooks.body.data.results[0].name).toEqual(book2.body.name);
   expect(allBooks.body.data.results[1].name).toEqual(book1.body.name);
+});
+
+it('returns only safe uploader attribution from public book endpoints', async () => {
+  const { sender } = await global.signin();
+  const book = await Books.create({
+    name: 'safe uploader attribution book',
+    url: DUMMY_PDF_URL,
+    size: 100,
+    uploader: sender,
+  });
+  const uploaderId = String(sender);
+
+  const expectSafeUploader = (uploader: unknown) => {
+    expect(uploader).toEqual({ _id: uploaderId, username: 'test' });
+    expect(uploader).not.toHaveProperty('email');
+  };
+
+  const search = await request(app)
+    .get('/api/books/search')
+    .query({ q: 'safe uploader attribution book' })
+    .expect(200);
+  expectSafeUploader(search.body.results[0].uploader);
+
+  const allBooks = await request(app)
+    .get('/api/books/allBooks')
+    .query({ language: 'all', page: 1, limit: 10 })
+    .expect(200);
+  expectSafeUploader(allBooks.body.data.results[0].uploader);
+
+  const ratingSortedBooks = await request(app)
+    .get('/api/books/allBooks')
+    .query({ language: 'all', page: 1, limit: 10, sort: 'ratingDesc' })
+    .expect(200);
+  expectSafeUploader(ratingSortedBooks.body.data.results[0].uploader);
+
+  const recentlyAdded = await request(app)
+    .get('/api/books/recently-added')
+    .query({ page: 1, limit: 10 })
+    .expect(200);
+  expectSafeUploader(recentlyAdded.body.data.books[0].uploader);
+
+  const detail = await request(app).get(`/api/books/getBookById/${book._id}`).expect(200);
+  expectSafeUploader(detail.body.uploader);
 });

--- a/backend/routes/api/books.ts
+++ b/backend/routes/api/books.ts
@@ -33,7 +33,6 @@ router.post(
       .withMessage('Name must be at most 200 characters'),
     body('url').not().isEmpty().withMessage('Url is required'),
     body('size').not().isEmpty().withMessage('Size is required'),
-    body('uploader').not().isEmpty().withMessage('Uploader is required'),
     body('author')
       .optional({ nullable: true })
       .isString()

--- a/backend/routes/api/books.types.ts
+++ b/backend/routes/api/books.types.ts
@@ -1,4 +1,14 @@
+import type { Types } from 'mongoose';
 import type { IBook } from '../../models/Books';
+
+export interface PublicUploader {
+  _id: Types.ObjectId;
+  username: string;
+}
+
+export type PublicBook = Omit<IBook, 'uploader'> & {
+  uploader?: PublicUploader | null;
+};
 
 export interface ImageLinks {
   smallThumbnail?: string;
@@ -32,7 +42,7 @@ export interface GoogleBooksResponse {
 }
 
 export interface BooksData {
-  results: IBook[];
+  results: PublicBook[];
   total: number;
   page?: number;
   next?: {

--- a/backend/services/book/addNewBook.service.ts
+++ b/backend/services/book/addNewBook.service.ts
@@ -1,6 +1,8 @@
 // addNewBook.service.ts
 import type { Request } from 'express';
+import type { Types } from 'mongoose';
 import * as webpush from 'web-push';
+import { NotAuthorizedError } from '../../errors/not-authorized-error';
 import { logger } from '../../logger';
 import { Books } from '../../models/Books';
 import { getUserSubscriptionsExcludingUser, removeSubscription } from '../../web-push';
@@ -16,7 +18,18 @@ const getTrimmedString = (value: unknown): string | undefined => {
   return trimmed || undefined;
 };
 
+interface AuthenticatedUser {
+  _id?: Types.ObjectId | string;
+}
+
 const addNewBook = async (req: Request) => {
+  const user = req.user as AuthenticatedUser | undefined;
+  const uploaderId = user?._id;
+
+  if (!uploaderId) {
+    throw new NotAuthorizedError();
+  }
+
   const incomingName = typeof req.body.name === 'string' ? req.body.name : undefined;
   const nameForLookup = getTrimmedString(incomingName);
   const manualAuthor = getTrimmedString(req.body.author);
@@ -42,7 +55,7 @@ const addNewBook = async (req: Request) => {
     url: req.body.url,
     size: req.body.size,
     date: new Date(),
-    uploader: req.body.uploader,
+    uploader: uploaderId,
     author: manualAuthor ?? metadata?.author ?? null,
     isbn: manualIsbn ?? metadata?.isbn ?? null,
     publisher: manualPublisher ?? metadata?.publisher ?? null,
@@ -64,14 +77,12 @@ const addNewBook = async (req: Request) => {
 
   await books.save();
 
-  const user = req.user as any;
-
   const payload = JSON.stringify({
     title: 'New Book Added',
     body: `A new book "${books.name}" has been added!`,
   });
 
-  const subscriptions = await getUserSubscriptionsExcludingUser(user.id);
+  const subscriptions = await getUserSubscriptionsExcludingUser(uploaderId.toString());
 
   subscriptions.forEach((subscription) => {
     if (subscription?.subscription?.endpoint) {

--- a/backend/services/book/getAllBooks.service.ts
+++ b/backend/services/book/getAllBooks.service.ts
@@ -2,7 +2,7 @@
 import type { Request } from 'express';
 import { logger } from '../../logger';
 import { Books } from '../../models/Books';
-import type { BooksData } from '../../routes/api/books.types';
+import type { BooksData, PublicBook, PublicUploader } from '../../routes/api/books.types';
 import { apiResponse } from '../../utils/apiResponse.utils';
 
 function escapeRegExp(input: string): string {
@@ -123,14 +123,17 @@ const getAllBooksService = async (req: Request) => {
       // populate uploader after aggregation
       await Books.populate(books, {
         path: 'uploader',
-        select: 'username email',
+        select: '_id username',
       });
     } else {
       books = await Books.find(
         query,
         'name path size date url uploader category language description imageLinks author isbn publisher'
       )
-        .populate('uploader', 'username email')
+        .populate<{ uploader: PublicUploader | null }>({
+          path: 'uploader',
+          select: '_id username',
+        })
         .sort(sort)
         .skip(startIndex)
         .limit(limit)
@@ -138,7 +141,7 @@ const getAllBooksService = async (req: Request) => {
     }
 
     const results: BooksData = {
-      results: books as any,
+      results: books as unknown as PublicBook[],
       total,
       page,
       next: total > startIndex + limit ? { page: page + 1 } : undefined,

--- a/backend/services/book/getBookById.service.ts
+++ b/backend/services/book/getBookById.service.ts
@@ -1,10 +1,14 @@
 // getBookById.service.ts
-import { Request } from 'express';
+import type { Request } from 'express';
 import { Books } from '../../models/Books';
+import type { PublicUploader } from '../../routes/api/books.types';
 
 const getBookById = async (req: Request) => {
   const id = req.params.id;
-  const book = await Books.findById(id);
+  const book = await Books.findById(id).populate<{ uploader: PublicUploader | null }>({
+    path: 'uploader',
+    select: '_id username',
+  });
 
   return book;
 };

--- a/backend/services/book/recentlyAddedBooks.service.ts
+++ b/backend/services/book/recentlyAddedBooks.service.ts
@@ -1,5 +1,6 @@
 // recentlyAddedBooks.service.ts
 import { Books } from '../../models/Books';
+import type { PublicBook, PublicUploader } from '../../routes/api/books.types';
 import { apiResponse } from '../../utils/apiResponse.utils';
 
 interface PaginationParams {
@@ -8,7 +9,7 @@ interface PaginationParams {
 }
 
 interface PaginatedBooksResponse {
-  books: any[];
+  books: PublicBook[];
   pagination: {
     currentPage: number;
     totalPages: number;
@@ -27,11 +28,15 @@ const getRecentlyAddedBooks = async (params: PaginationParams = {}) => {
     const totalBooks = await Books.countDocuments({});
 
     // Get paginated books
-    const books = await Books.find({})
+    const books = (await Books.find({})
       .sort({ date: -1, createdAt: -1 }) // Sort by date first, then createdAt
       .skip(skip)
       .limit(limit)
-      .exec();
+      .populate<{ uploader: PublicUploader | null }>({
+        path: 'uploader',
+        select: '_id username',
+      })
+      .exec()) as unknown as PublicBook[];
 
     const totalPages = Math.ceil(totalBooks / limit);
     const hasMore = page < totalPages;
@@ -47,15 +52,9 @@ const getRecentlyAddedBooks = async (params: PaginationParams = {}) => {
       },
     };
 
-    return apiResponse(
-      200,
-      'success',
-      'Recently added books fetched successfully',
-      response
-    );
+    return apiResponse(200, 'success', 'Recently added books fetched successfully', response);
   } catch (error) {
-    const errorMessage =
-      error instanceof Error ? error.message : 'Unknown error occurred';
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
     throw new Error(`Failed to fetch recently added books: ${errorMessage}`);
   }
 };

--- a/backend/services/book/searchBooks.service.ts
+++ b/backend/services/book/searchBooks.service.ts
@@ -1,6 +1,7 @@
 import type { Request } from 'express';
 import NodeCache from 'node-cache';
 import { Books } from '../../models/Books';
+import type { PublicBook, PublicUploader } from '../../routes/api/books.types';
 import { logSearchAnalytics } from '../analytics/logSearch.service';
 
 const SEARCH_CACHE_TTL_SECONDS = 60;
@@ -148,7 +149,10 @@ const searchBooksService = async (req: Request) => {
       .select(
         'name path size date url uploader category language description imageLinks author isbn publisher'
       )
-      .populate('uploader', 'username email')
+      .populate<{ uploader: PublicUploader | null }>({
+        path: 'uploader',
+        select: '_id username',
+      })
       .collation({ locale: 'tr', strength: 2 })
       .skip(startIndex)
       .limit(limit)
@@ -167,10 +171,10 @@ const searchBooksService = async (req: Request) => {
       page: number;
       limit: number;
     };
-    results: unknown[];
+    results: PublicBook[];
   } = {
     total: count,
-    results,
+    results: results as unknown as PublicBook[],
   };
 
   if (endIndex < count) {

--- a/client/src/book-table/column.tsx
+++ b/client/src/book-table/column.tsx
@@ -1,29 +1,26 @@
-import { ColumnDef } from '@tanstack/react-table';
-import { toast } from 'sonner';
-import {
-  DropdownMenu,
-  DropdownMenuTrigger,
-} from '../components/ui/dropdown-menu';
-import { Button } from '../components/ui/button';
+import type { ColumnDef } from '@tanstack/react-table';
 import { DownloadIcon, Edit, MoreHorizontal } from 'lucide-react';
-import { DropdownMenuContent } from '../components/ui/dropdown-menu';
-import { DropdownMenuLabel } from '../components/ui/dropdown-menu';
-import { DropdownMenuItem } from '../components/ui/dropdown-menu';
-import { DropdownMenuSeparator } from '../components/ui/dropdown-menu';
 import { AiOutlineDelete } from 'react-icons/ai';
 import { useSelector } from 'react-redux';
-
 import { Link } from 'react-router-dom';
 import { useDeleteBookMutation } from 'redux/services/book.api';
-import { RootState } from 'redux/store';
-import { downloadBook } from '@/helpers/downloadBook';
+import type { RootState } from 'redux/store';
+import { toast } from 'sonner';
 import { Badge } from '@/components/ui/badge';
-import { Book } from '@/models/book.model';
+import { downloadBook } from '@/helpers/downloadBook';
+import type { Book } from '@/models/book.model';
+import { Button } from '../components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '../components/ui/dropdown-menu';
 
 const BookOptions = ({ row }: { row: { original: Book } }) => {
-  const { user, isLoggedIn } = useSelector(
-    (state: RootState) => state.authSlice
-  );
+  const { user, isLoggedIn } = useSelector((state: RootState) => state.authSlice);
 
   const [deleteBook, { isSuccess, isError }] = useDeleteBookMutation();
 
@@ -56,10 +53,7 @@ const BookOptions = ({ row }: { row: { original: Book } }) => {
         <DropdownMenuSeparator />
         {
           <DropdownMenuItem disabled={!isAdmin}>
-            <Link
-              className="cursor-pointer"
-              to={`/book/edit/${row.original._id}`}
-            >
+            <Link className="cursor-pointer" to={`/book/edit/${row.original._id}`}>
               <div className="flex">
                 <Edit className="h-4 w-4 mr-2" />
                 <span>Edit Book</span>
@@ -84,9 +78,7 @@ export const columns: ColumnDef<Book>[] = [
   {
     accessorKey: 'name',
     header: () => (
-      <div className="text-green-800 dark:text-green-400 font-bold text-base">
-        Name
-      </div>
+      <div className="text-green-800 dark:text-green-400 font-bold text-base">Name</div>
     ),
     cell: ({ row }) => (
       <Link
@@ -113,10 +105,10 @@ export const columns: ColumnDef<Book>[] = [
             index % 4 === 0
               ? 'default'
               : index % 4 === 1
-              ? 'success'
-              : index % 4 === 2
-              ? 'info'
-              : 'warning'
+                ? 'success'
+                : index % 4 === 2
+                  ? 'info'
+                  : 'warning'
           }
           className="text-xs max-w-36 truncate hidden md:inline-flex m-1"
           key={category}
@@ -149,11 +141,15 @@ export const columns: ColumnDef<Book>[] = [
       </div>
     ),
     accessorKey: 'uploader',
-    cell: ({ row }) => (
-      <div className="text-gray-500 dark:text-gray-300 hidden md:flex">
-        {row.original.uploader.username}
-      </div>
-    ),
+    cell: ({ row }) => {
+      const uploader = row.original.uploader;
+
+      return (
+        <div className="text-gray-500 dark:text-gray-300 hidden md:flex">
+          {typeof uploader === 'object' && uploader?.username}
+        </div>
+      );
+    },
   },
   {
     id: 'actions',

--- a/client/src/components/__tests__/Search.test.tsx
+++ b/client/src/components/__tests__/Search.test.tsx
@@ -36,7 +36,6 @@ const resultWithMetadata = {
   uploader: {
     username: 'uploader-name',
     _id: 'user-1',
-    email: 'uploader@example.com',
   },
   category: ['Fiction'],
   language: 'English',

--- a/client/src/models/book.model.ts
+++ b/client/src/models/book.model.ts
@@ -11,7 +11,7 @@ export interface BookModel {
     size: number;
     url: string;
     date: string;
-    uploader: string;
+    uploader?: BookUploader | string | null;
     __v: number;
     category: string;
     language: string;
@@ -24,6 +24,11 @@ export interface BookModel {
       thumbnail: string;
     };
   }[];
+}
+
+export interface BookUploader {
+  _id: string;
+  username: string;
 }
 
 export interface Book {
@@ -43,11 +48,7 @@ export interface Book {
     smallThumbnail: string;
     thumbnail: string;
   };
-  uploader: {
-    username: string;
-    _id: string;
-    email: string;
-  };
+  uploader?: BookUploader | string | null;
 }
 export interface BooksData {
   results: Book[];

--- a/client/src/pages/BookPreview/components/BookDetails.tsx
+++ b/client/src/pages/BookPreview/components/BookDetails.tsx
@@ -15,6 +15,7 @@ export const BookDetails: React.FC<BookDetailsProps> = ({ book, fileType }) => {
   const { data: summary } = useGetBookRatingSummaryQuery(book._id);
   const avg = useMemo(() => Number(summary?.data?.avgRating || 0), [summary]);
   const count = summary?.data?.count || 0;
+  const uploader = book.uploader;
 
   return (
     <Card>
@@ -23,10 +24,10 @@ export const BookDetails: React.FC<BookDetailsProps> = ({ book, fileType }) => {
           <div>
             <h1 className="text-3xl font-bold text-foreground mb-2">{book.name}</h1>
             <div className="flex items-center space-x-4 text-sm text-muted-foreground">
-              {book.uploader?.username && (
+              {typeof uploader === 'object' && uploader?.username && (
                 <div className="flex items-center">
                   <User className="h-4 w-4 mr-1" />
-                  {book.uploader.username}
+                  {uploader.username}
                 </div>
               )}
               {book.language && (

--- a/client/src/pages/UploadNewBook.tsx
+++ b/client/src/pages/UploadNewBook.tsx
@@ -16,7 +16,6 @@ import {
   Label,
   Progress,
 } from '@/components/ui';
-import { useAppSelector } from '@/redux/store';
 import Layout from '../components/Layout';
 import { useAddNewBookMutation } from '../redux/services/book.api';
 
@@ -45,8 +44,6 @@ export default function UploadNewBook() {
   const [manualMetadata, setManualMetadata] = useState<ManualMetadata>(emptyManualMetadata);
   const metadataFileIdRef = useRef<string | undefined>(undefined);
   const [addNewBook] = useAddNewBookMutation();
-  const user = useAppSelector((state) => state.authSlice.user.user);
-  const userId = user.id || user.username;
 
   const uploadToCloudinary = async (file: File): Promise<any> => {
     const formData = new FormData();
@@ -70,7 +67,6 @@ export default function UploadNewBook() {
       name: originalFile.name,
       size: response.bytes,
       url: response.secure_url,
-      uploader: userId,
       ...(metadata?.author.trim() && { author: metadata.author.trim() }),
       ...(metadata?.isbn.trim() && { isbn: metadata.isbn.trim() }),
       ...(metadata?.publisher.trim() && {

--- a/client/src/redux/services/book.api.ts
+++ b/client/src/redux/services/book.api.ts
@@ -97,7 +97,6 @@ export const bookApi = commonApi.injectEndpoints({
         name: string;
         size: string;
         url: string;
-        uploader: string;
         author?: string | null;
         isbn?: string | null;
         publisher?: string | null;

--- a/client/tests/fixtures/book.fixture.ts
+++ b/client/tests/fixtures/book.fixture.ts
@@ -24,7 +24,6 @@ export const mockBook = {
   uploader: {
     username: 'test-uploader',
     _id: 'uploader-id-001',
-    email: 'uploader@example.com',
   },
 };
 


### PR DESCRIPTION
## Summary
- expose only uploader id and username from public book endpoints
- derive new-book ownership from the authenticated user instead of request input
- remove uploader email from client contracts and fixtures
- add regression coverage for public PII and uploader spoofing

## API behavior
- search, all-books, recently-added, rating-sorted, and detail responses use the same safe uploader shape
- legacy clients may still send `uploader`, but the backend ignores it

## Verification
- backend tests: 35 passed
- backend build: passed
- client tests: 34 passed
- client build: passed
- client E2E: 7 passed
- Biome staged and CI checks: passed

## Database impact
- no schema, index, migration, backfill, or existing-data mutation

## Risk
- payload contract intentionally removes uploader email; username attribution remains

Closes #354