### PR TITLE
fix: make token refresh single-flight

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,9 +4,10 @@ import ReactGA from 'react-ga4';
 import { useLocation, useNavigate } from 'react-router-dom';
 import Layout from './components/Layout';
 import { Search } from './components/Search';
-import { loadUserThunk, refreshTokenThunk } from './redux/authSlice';
+import { loadUserThunk } from './redux/authSlice';
 import { apiBaseUrl } from './redux/common.api';
 import { useAppDispatch, useAppSelector } from './redux/store';
+import { handleAuthExpiredOnce, refreshAccessToken } from './redux/tokenRefresh';
 
 ReactGA.initialize('G-R54SYJD2B8');
 
@@ -119,9 +120,11 @@ function App() {
 
     const interval = setInterval(
       () => {
-        dispatch(refreshTokenThunk()).catch(() => {
-          // Token refresh failed, user will be logged out by the thunk
-          console.log('Token refresh failed');
+        void refreshAccessToken(apiBaseUrl).then((result) => {
+          if (result.status === 'auth-expired') {
+            handleAuthExpiredOnce(dispatch);
+          }
+          // Network errors are best-effort: keep the session for the next tick.
         });
       },
       10 * 60 * 1000

--- a/client/src/redux/__tests__/common.api.test.ts
+++ b/client/src/redux/__tests__/common.api.test.ts
@@ -1,0 +1,112 @@
+import type { BaseQueryApi } from '@reduxjs/toolkit/dist/query/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createBaseQueryWithReauth } from '../common.api';
+import { resetTokenRefreshStateForTests } from '../tokenRefresh';
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+let mockFetch: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  resetTokenRefreshStateForTests();
+  sessionStorage.clear();
+  mockFetch = vi.fn();
+  vi.stubGlobal('fetch', mockFetch);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  sessionStorage.clear();
+  resetTokenRefreshStateForTests();
+});
+
+const unauthorized = { error: { status: 401, data: 'unauthorized' } };
+const okData = { data: { ok: true } };
+
+const makeBaseApi = (dispatch: (action: unknown) => void) =>
+  ({ dispatch }) as unknown as BaseQueryApi;
+
+describe('createBaseQueryWithReauth', () => {
+  it('passes through non-401 results without refreshing', async () => {
+    const fakeBaseQuery = vi.fn(async () => okData);
+    const wrapper = createBaseQueryWithReauth(fakeBaseQuery);
+    const dispatch = vi.fn();
+
+    const result = await wrapper('/books', makeBaseApi(dispatch), {});
+
+    expect(result).toEqual(okData);
+    expect(fakeBaseQuery).toHaveBeenCalledTimes(1);
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('runs one refresh for 100 concurrent 401s and retries each request once', async () => {
+    sessionStorage.setItem('auth_rt', 'rt');
+    mockFetch.mockResolvedValue(jsonResponse({ tokens: { accessToken: 'fresh-token' } }));
+    const fakeBaseQuery = vi.fn(async () =>
+      fakeBaseQuery.mock.calls.length <= 100 ? unauthorized : okData
+    );
+    const wrapper = createBaseQueryWithReauth(fakeBaseQuery);
+    const dispatch = vi.fn();
+
+    const results = await Promise.all(
+      Array.from({ length: 100 }, () => wrapper('/books', makeBaseApi(dispatch), {}))
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(fakeBaseQuery).toHaveBeenCalledTimes(200);
+    expect(results.every((r) => r.error === undefined)).toBe(true);
+    expect(sessionStorage.getItem('auth_at')).toBe('fresh-token');
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('does not loop on retry 401 and dispatches logout exactly once', async () => {
+    sessionStorage.setItem('auth_at', 'old-at');
+    sessionStorage.setItem('auth_rt', 'old-rt');
+    mockFetch.mockResolvedValue(jsonResponse({ tokens: { accessToken: 'fresh' } }));
+    const fakeBaseQuery = vi.fn(async () => unauthorized);
+    const wrapper = createBaseQueryWithReauth(fakeBaseQuery);
+    const dispatch = vi.fn();
+
+    const results = await Promise.all(
+      Array.from({ length: 3 }, () => wrapper('/books', makeBaseApi(dispatch), {}))
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(fakeBaseQuery).toHaveBeenCalledTimes(6); // 3 initial + 3 retries, no loop
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledWith({ type: 'loginSlice/logout' });
+    expect(sessionStorage.getItem('auth_at')).toBeNull();
+    expect(sessionStorage.getItem('auth_rt')).toBeNull();
+    for (const result of results) {
+      expect(result.error?.status).toBe(401);
+    }
+  });
+
+  it('keeps tokens and session when the refresh network call fails', async () => {
+    sessionStorage.setItem('auth_at', 'at');
+    sessionStorage.setItem('auth_rt', 'rt');
+    mockFetch.mockRejectedValue(new TypeError('Failed to fetch'));
+    const fakeBaseQuery = vi.fn(async () => unauthorized);
+    const wrapper = createBaseQueryWithReauth(fakeBaseQuery);
+    const dispatch = vi.fn();
+
+    const results = await Promise.all(
+      Array.from({ length: 2 }, () => wrapper('/books', makeBaseApi(dispatch), {}))
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(fakeBaseQuery).toHaveBeenCalledTimes(2); // no retry after network refresh failure
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(sessionStorage.getItem('auth_at')).toBe('at');
+    expect(sessionStorage.getItem('auth_rt')).toBe('rt');
+    for (const result of results) {
+      expect(result.error?.status).toBe(401);
+    }
+  });
+});

--- a/client/src/redux/__tests__/tokenRefresh.test.ts
+++ b/client/src/redux/__tests__/tokenRefresh.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  handleAuthExpiredOnce,
+  markAuthSessionActive,
+  refreshAccessToken,
+  resetTokenRefreshStateForTests,
+} from '../tokenRefresh';
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+let mockFetch: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  resetTokenRefreshStateForTests();
+  sessionStorage.clear();
+  mockFetch = vi.fn();
+  vi.stubGlobal('fetch', mockFetch);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  sessionStorage.clear();
+  resetTokenRefreshStateForTests();
+});
+
+describe('refreshAccessToken', () => {
+  it('shares one refresh across 100 concurrent callers and all succeed', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ tokens: { accessToken: 'shared' } }));
+
+    const results = await Promise.all(
+      Array.from({ length: 100 }, () => refreshAccessToken('/api'))
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(results).toHaveLength(100);
+    expect(results.every((r) => r.status === 'success')).toBe(true);
+    expect(sessionStorage.getItem('auth_at')).toBe('shared');
+  });
+
+  it('stores the new access token before resolving success', async () => {
+    const gate = deferred<Response>();
+    mockFetch.mockReturnValue(gate.promise);
+
+    const refreshPromise = refreshAccessToken('/api');
+    expect(sessionStorage.getItem('auth_at')).toBeNull();
+
+    gate.resolve(jsonResponse({ tokens: { accessToken: 'new-token' } }));
+    const result = await refreshPromise;
+
+    expect(result).toEqual({ status: 'success' });
+    expect(sessionStorage.getItem('auth_at')).toBe('new-token');
+  });
+
+  it('maps a non-OK refresh response to auth-expired without storing a token', async () => {
+    mockFetch.mockResolvedValue(new Response('Unauthorized', { status: 401 }));
+
+    const result = await refreshAccessToken('/api');
+
+    expect(result).toEqual({ status: 'auth-expired' });
+    expect(sessionStorage.getItem('auth_at')).toBeNull();
+  });
+
+  it('maps a 500 refresh response to network-error, preserving the session', async () => {
+    sessionStorage.setItem('auth_at', 'at');
+    sessionStorage.setItem('auth_rt', 'rt');
+    mockFetch.mockResolvedValue(new Response('Server Error', { status: 500 }));
+
+    const result = await refreshAccessToken('/api');
+
+    expect(result).toEqual({ status: 'network-error' });
+    expect(sessionStorage.getItem('auth_at')).toBe('at');
+    expect(sessionStorage.getItem('auth_rt')).toBe('rt');
+  });
+
+  it('maps a rejected fetch to network-error', async () => {
+    mockFetch.mockRejectedValue(new TypeError('Failed to fetch'));
+
+    const result = await refreshAccessToken('/api');
+
+    expect(result).toEqual({ status: 'network-error' });
+  });
+
+  it('starts a fresh request after the in-flight one settles', async () => {
+    // Return a fresh Response per call so each body can be consumed once.
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(jsonResponse({ tokens: { accessToken: 't1' } }))
+    );
+
+    expect(await refreshAccessToken('/api')).toEqual({ status: 'success' });
+    expect(await refreshAccessToken('/api')).toEqual({ status: 'success' });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('posts with credentials and the encoded refresh token query fallback', async () => {
+    sessionStorage.setItem('auth_rt', 'a b&c=/');
+    mockFetch.mockResolvedValue(jsonResponse({ tokens: { accessToken: 't' } }));
+
+    await refreshAccessToken('/api');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe(`/api/user/refresh-token?rt=${encodeURIComponent('a b&c=/')}`);
+    expect(init.method).toBe('POST');
+    expect(init.credentials).toBe('include');
+  });
+});
+
+describe('handleAuthExpiredOnce', () => {
+  it('clears both storage keys and dispatches logout once across repeated callers', () => {
+    sessionStorage.setItem('auth_at', 'at');
+    sessionStorage.setItem('auth_rt', 'rt');
+    const dispatch = vi.fn();
+
+    handleAuthExpiredOnce(dispatch);
+    handleAuthExpiredOnce(dispatch);
+    handleAuthExpiredOnce(dispatch);
+
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledWith({ type: 'loginSlice/logout' });
+    expect(sessionStorage.getItem('auth_at')).toBeNull();
+    expect(sessionStorage.getItem('auth_rt')).toBeNull();
+  });
+
+  it('re-arms the one-shot guard after a successful refresh', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ tokens: { accessToken: 'fresh' } }));
+    const dispatch = vi.fn();
+
+    handleAuthExpiredOnce(dispatch);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+
+    await refreshAccessToken('/api');
+
+    handleAuthExpiredOnce(dispatch);
+    expect(dispatch).toHaveBeenCalledTimes(2);
+  });
+
+  it('re-arms the one-shot guard via markAuthSessionActive (same-tab re-login)', () => {
+    sessionStorage.setItem('auth_at', 'at');
+    sessionStorage.setItem('auth_rt', 'rt');
+    const dispatch = vi.fn();
+
+    handleAuthExpiredOnce(dispatch);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+
+    markAuthSessionActive();
+
+    handleAuthExpiredOnce(dispatch);
+    expect(dispatch).toHaveBeenCalledTimes(2);
+    expect(sessionStorage.getItem('auth_at')).toBeNull();
+    expect(sessionStorage.getItem('auth_rt')).toBeNull();
+  });
+});

--- a/client/src/redux/authSlice.tsx
+++ b/client/src/redux/authSlice.tsx
@@ -1,6 +1,7 @@
-import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
-import axios, { AxiosError } from 'axios';
+import { createAsyncThunk, createSlice, type PayloadAction } from '@reduxjs/toolkit';
+import axios, { type AxiosError } from 'axios';
 import { apiBaseUrl } from './common.api';
+import { markAuthSessionActive } from './tokenRefresh';
 
 // Define proper interfaces
 interface User {
@@ -50,7 +51,7 @@ export const loginThunk = createAsyncThunk(
           withCredentials: true,
         }
       );
-      
+
       // Store tokens in sessionStorage for cross-domain fallback
       if (res.data.tokens?.accessToken && typeof window !== 'undefined') {
         sessionStorage.setItem('auth_at', res.data.tokens.accessToken);
@@ -58,7 +59,11 @@ export const loginThunk = createAsyncThunk(
           sessionStorage.setItem('auth_rt', res.data.tokens.refreshToken);
         }
       }
-      
+
+      // Re-arm the one-shot auth-expiry guard so a later confirmed expiry
+      // (e.g. after a same-tab re-login) can dispatch logout again.
+      markAuthSessionActive();
+
       return res.data;
     } catch (error) {
       const err = error as AxiosError;
@@ -67,42 +72,36 @@ export const loginThunk = createAsyncThunk(
   }
 );
 
-export const logoutThunk = createAsyncThunk(
-  'authSlice/logout',
-  async (_, { rejectWithValue }) => {
-    try {
-      const at =
-        typeof window !== 'undefined'
-          ? sessionStorage.getItem('auth_at')
-          : null;
-      const res = await axios.post(
-        `${apiBaseUrl}/user/logout`,
-        {},
-        {
-          withCredentials: true,
-          headers: at ? { Authorization: `Bearer ${at}` } : undefined,
-        }
-      );
-      return res.data;
-    } catch (error) {
-      const err = error as AxiosError;
-      return rejectWithValue(err.message);
-    }
+export const logoutThunk = createAsyncThunk('authSlice/logout', async (_, { rejectWithValue }) => {
+  try {
+    const at = typeof window !== 'undefined' ? sessionStorage.getItem('auth_at') : null;
+    const res = await axios.post(
+      `${apiBaseUrl}/user/logout`,
+      {},
+      {
+        withCredentials: true,
+        headers: at ? { Authorization: `Bearer ${at}` } : undefined,
+      }
+    );
+    return res.data;
+  } catch (error) {
+    const err = error as AxiosError;
+    return rejectWithValue(err.message);
   }
-);
+});
 
 export const loadUserThunk = createAsyncThunk(
   'authSlice/loadUser',
   async (_, { rejectWithValue }) => {
     try {
-      const at =
-        typeof window !== 'undefined'
-          ? sessionStorage.getItem('auth_at')
-          : null;
+      const at = typeof window !== 'undefined' ? sessionStorage.getItem('auth_at') : null;
       const res = await axios.get(`${apiBaseUrl}/user/auth`, {
         withCredentials: true,
         headers: at ? { Authorization: `Bearer ${at}` } : undefined,
       });
+      // A successful load-user confirms the session is live (covers OAuth /
+      // cookie sessions); re-arm the one-shot auth-expiry guard.
+      markAuthSessionActive();
       return res.data;
     } catch (error) {
       const err = error as AxiosError;
@@ -134,39 +133,7 @@ export const registerThunk = createAsyncThunk(
       return res.data;
     } catch (error) {
       const err = error as AxiosError<{ errors: Array<{ message: string }> }>;
-      return rejectWithValue(
-        err.response?.data.errors?.[0]?.message || 'Registration failed'
-      );
-    }
-  }
-);
-
-export const refreshTokenThunk = createAsyncThunk(
-  'authSlice/refreshToken',
-  async (_, { rejectWithValue }) => {
-    try {
-      const rt = 
-        typeof window !== 'undefined' 
-          ? sessionStorage.getItem('auth_rt') 
-          : null;
-      
-      const url = rt 
-        ? `${apiBaseUrl}/user/refresh-token?rt=${encodeURIComponent(rt)}`
-        : `${apiBaseUrl}/user/refresh-token`;
-      
-      const res = await axios.post(url, {}, {
-        withCredentials: true,
-      });
-      
-      // Store new access token in sessionStorage for cross-domain fallback
-      if (res.data.tokens?.accessToken && typeof window !== 'undefined') {
-        sessionStorage.setItem('auth_at', res.data.tokens.accessToken);
-      }
-      
-      return res.data;
-    } catch (error) {
-      const err = error as AxiosError;
-      return rejectWithValue(err.message);
+      return rejectWithValue(err.response?.data.errors?.[0]?.message || 'Registration failed');
     }
   }
 );
@@ -283,7 +250,7 @@ export const authSlice = createSlice({
         state.loginSuccess = false;
         state.isAuthLoaded = true; // Auth check completed
       })
-      .addCase(registerThunk.fulfilled, (state, action) => {
+      .addCase(registerThunk.fulfilled, (state) => {
         state.isLoading = false;
         state.loginSuccess = true;
         state.error = false;
@@ -300,28 +267,6 @@ export const authSlice = createSlice({
         state.errorMessage = action.payload as string;
         state.isLoading = false;
         state.isAuthLoaded = true; // Auth check completed
-      })
-      .addCase(refreshTokenThunk.fulfilled, (state, action) => {
-        state.user = action.payload;
-        state.isLoggedIn = true;
-        state.isAuthLoaded = true;
-      })
-      .addCase(refreshTokenThunk.rejected, (state) => {
-        state.isLoggedIn = false;
-        state.isAuthLoaded = true;
-        state.user = {
-          user: {
-            id: '',
-            username: '',
-            email: '',
-            isAdmin: false,
-          },
-        };
-        // Clear stored tokens on refresh failure
-        if (typeof window !== 'undefined') {
-          sessionStorage.removeItem('auth_at');
-          sessionStorage.removeItem('auth_rt');
-        }
       });
   },
 });

--- a/client/src/redux/common.api.ts
+++ b/client/src/redux/common.api.ts
@@ -1,12 +1,16 @@
-import { createApi, fetchBaseQuery, BaseQueryFn, FetchArgs, FetchBaseQueryError } from '@reduxjs/toolkit/dist/query/react';
+import {
+  type BaseQueryFn,
+  createApi,
+  type FetchArgs,
+  type FetchBaseQueryError,
+  fetchBaseQuery,
+} from '@reduxjs/toolkit/dist/query/react';
+import { handleAuthExpiredOnce, refreshAccessToken } from './tokenRefresh';
 
 // In production, hit backend domain directly so backend cookies are sent (Chrome),
 // while we also attach Bearer from sessionStorage for Safari fallback
-const prodApi =
-  (import.meta.env.VITE_PROD_API as string | undefined) ||
-  '/api';
-export const apiBaseUrl =
-  import.meta.env.PROD ? prodApi : '/api';
+const prodApi = (import.meta.env.VITE_PROD_API as string | undefined) || '/api';
+export const apiBaseUrl = import.meta.env.PROD ? prodApi : '/api';
 
 const baseQuery = fetchBaseQuery({
   baseUrl: apiBaseUrl,
@@ -21,43 +25,46 @@ const baseQuery = fetchBaseQuery({
   credentials: 'include',
 });
 
-const baseQueryWithReauth: BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError> = async (
-  args,
-  api,
-  extraOptions
-) => {
-  let result = await baseQuery(args, api, extraOptions);
-  
-  if (result.error && result.error.status === 401) {
-    // Try to refresh token
-    const rt = sessionStorage.getItem('auth_rt');
-    const refreshUrl = rt 
-      ? `${apiBaseUrl}/user/refresh-token?rt=${encodeURIComponent(rt)}`
-      : `${apiBaseUrl}/user/refresh-token`;
-    
-    const refreshResult = await baseQuery(
-      { url: refreshUrl.replace(apiBaseUrl, ''), method: 'POST' },
-      api,
-      extraOptions
-    );
-    
-    if (refreshResult.data) {
-      // Refresh successful, retry original request
-      result = await baseQuery(args, api, extraOptions);
-    } else {
-      // Refresh failed, clear tokens and redirect to login
-      sessionStorage.removeItem('auth_at');
-      sessionStorage.removeItem('auth_rt');
-      window.location.href = '/login';
+/**
+ * Wraps a raw base query with single-flight token refresh. On the first 401 the
+ * shared refresh runs; on success the original request is retried exactly once.
+ * A second 401 or a confirmed refresh failure clears tokens and dispatches logout
+ * once; a network refresh failure keeps the session intact.
+ */
+export const createBaseQueryWithReauth =
+  (
+    rawBaseQuery: BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError>
+  ): BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError> =>
+  async (args, api, extraOptions) => {
+    const first = await rawBaseQuery(args, api, extraOptions);
+
+    if (first.error?.status !== 401) {
+      return first;
     }
-  }
-  
-  return result;
-};
+
+    const refreshResult = await refreshAccessToken(apiBaseUrl);
+
+    if (refreshResult.status === 'success') {
+      // New access token is already persisted; retry the original request once.
+      const retry = await rawBaseQuery(args, api, extraOptions);
+      if (retry.error?.status === 401) {
+        // Still unauthorized with a fresh token: confirmed auth expiry.
+        handleAuthExpiredOnce(api.dispatch);
+      }
+      return retry;
+    }
+
+    if (refreshResult.status === 'auth-expired') {
+      handleAuthExpiredOnce(api.dispatch);
+    }
+
+    // network-error: keep tokens/session and return the original error.
+    return first;
+  };
 
 export const commonApi = createApi({
   reducerPath: 'api',
-  baseQuery: baseQueryWithReauth,
+  baseQuery: createBaseQueryWithReauth(baseQuery),
   tagTypes: ['Book', 'Messages'],
   endpoints: (_) => ({}),
 });

--- a/client/src/redux/tokenRefresh.ts
+++ b/client/src/redux/tokenRefresh.ts
@@ -1,0 +1,131 @@
+export type RefreshResult =
+  | { status: 'success' }
+  | { status: 'auth-expired' }
+  | { status: 'network-error' };
+
+const AT_KEY = 'auth_at';
+const RT_KEY = 'auth_rt';
+
+// Module-scope in-flight promise: every caller in the tab awaits exactly the
+// same refresh request until it settles, then a fresh one can be started.
+let inFlightRefresh: Promise<RefreshResult> | null = null;
+
+// One-shot guard: a confirmed auth expiry clears tokens and dispatches logout
+// at most once per failed session. A successful refresh (or an explicit login /
+// successful load-user) re-arms it so a later expiry can log out again.
+let authExpiredHandled = false;
+
+function getRefreshToken(): string | null {
+  try {
+    return sessionStorage.getItem(RT_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function setAccessToken(token: string): void {
+  try {
+    sessionStorage.setItem(AT_KEY, token);
+  } catch {
+    // Storage unavailable (e.g. private mode); cookie fallback still applies.
+  }
+}
+
+export function clearAuthTokens(): void {
+  try {
+    sessionStorage.removeItem(AT_KEY);
+    sessionStorage.removeItem(RT_KEY);
+  } catch {
+    // Storage unavailable; nothing to clear.
+  }
+}
+
+/**
+ * Re-arms the one-shot auth-expiry guard. Called after a successful token
+ * refresh, a successful login, and a successful load-user so a later confirmed
+ * expiry can dispatch logout again (e.g. same-tab re-login or OAuth/cookie
+ * sessions where no access token is persisted).
+ */
+export function markAuthSessionActive(): void {
+  authExpiredHandled = false;
+}
+
+/**
+ * Clears stored tokens and dispatches loginSlice/logout exactly once per
+ * failed session. Repeated callers before the next successful refresh are
+ * no-ops so concurrent 401 handling cannot double-dispatch.
+ */
+export function handleAuthExpiredOnce(dispatch: (action: { type: string }) => void): void {
+  if (authExpiredHandled) return;
+  authExpiredHandled = true;
+  clearAuthTokens();
+  dispatch({ type: 'loginSlice/logout' });
+}
+
+/**
+ * Single-flight access-token refresh. Callers share the in-flight request; a
+ * new one is only started after the previous one has settled.
+ */
+export function refreshAccessToken(apiBaseUrl: string): Promise<RefreshResult> {
+  if (!inFlightRefresh) {
+    inFlightRefresh = doRefresh(apiBaseUrl).finally(() => {
+      inFlightRefresh = null;
+    });
+  }
+  return inFlightRefresh;
+}
+
+async function doRefresh(apiBaseUrl: string): Promise<RefreshResult> {
+  const rt = getRefreshToken();
+  const url = rt
+    ? `${apiBaseUrl}/user/refresh-token?rt=${encodeURIComponent(rt)}`
+    : `${apiBaseUrl}/user/refresh-token`;
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+    });
+  } catch {
+    // Network failure: keep the session and tokens; callers may retry later.
+    return { status: 'network-error' };
+  }
+
+  // Only an explicit auth rejection confirms the session is dead. Any other
+  // non-OK status is treated as a transient server error so the existing
+  // session and tokens are preserved.
+  if (response.status === 401 || response.status === 403) {
+    return { status: 'auth-expired' };
+  }
+  if (!response.ok) {
+    return { status: 'network-error' };
+  }
+
+  let body: { tokens?: { accessToken?: unknown } } | null = null;
+  try {
+    body = await response.json();
+  } catch {
+    // Malformed success body: keep the session; callers may retry later.
+    return { status: 'network-error' };
+  }
+
+  const accessToken = body?.tokens?.accessToken;
+  if (typeof accessToken !== 'string' || accessToken.length === 0) {
+    // Missing token in a success body: keep the session; callers may retry.
+    return { status: 'network-error' };
+  }
+
+  // Persist the new access token before resolving success so retried requests
+  // carry it. Never log or return the token value itself.
+  setAccessToken(accessToken);
+  markAuthSessionActive();
+  return { status: 'success' };
+}
+
+// Test-only reset so Vitest can isolate module state between suites.
+export function resetTokenRefreshStateForTests(): void {
+  inFlightRefresh = null;
+  authExpiredHandled = false;
+}


### PR DESCRIPTION
## Summary
- deduplicate concurrent access-token refresh requests with one shared in-flight promise
- persist the refreshed access token before retrying each original API request once
- coordinate proactive and reactive refresh through the same function
- distinguish confirmed auth expiry from transient network/server failures
- dispatch logout exactly once and re-arm after re-login/OAuth load

## Concurrency behavior
- 100 concurrent 401 responses produce one refresh call
- each original request retries once after refresh
- a second 401 does not loop
- transient refresh failures preserve the current session for later retry

## Verification
- client tests: 48 passed
- concurrency tests: 100 callers / 1 refresh; 100 initial + 100 retries
- client build: passed
- client E2E: 7 passed
- Biome: passed

## Database/backend impact
- client-only; no schema, endpoint, token lifetime, migration, or dependency change

Closes #367