### PR TITLE
feat: add bounded bulk upload queue

### DIFF
--- a/client/src/hooks/__tests__/useUploadQueue.test.ts
+++ b/client/src/hooks/__tests__/useUploadQueue.test.ts
@@ -1,0 +1,416 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { CloudinaryAsset } from '../../services/cloudinaryUpload';
+import type { BatchSummary, SaveOperation, UploadItem } from '../useUploadQueue';
+import { CONCURRENCY, MAX_FILE_SIZE, MAX_FILES, useUploadQueue } from '../useUploadQueue';
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function saveOperation(promise: Promise<void> = Promise.resolve()): SaveOperation {
+  return { promise };
+}
+
+function makeFile(name: string, size = 1024, type = 'application/pdf', lastModified = 1): File {
+  const file = new File(['x'], name, { type, lastModified });
+  Object.defineProperty(file, 'size', { value: size, configurable: true });
+  Object.defineProperty(file, 'lastModified', {
+    value: lastModified,
+    configurable: true,
+  });
+  return file;
+}
+
+const asset: CloudinaryAsset = { secure_url: 'https://cdn.test/book', bytes: 128 };
+
+describe('useUploadQueue', () => {
+  it('drains 1000 files with at most 3 concurrent uploads and a terminal summary', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const upload = vi.fn(async (): Promise<CloudinaryAsset> => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await Promise.resolve();
+      inFlight -= 1;
+      return asset;
+    });
+    const save = vi.fn((): SaveOperation => saveOperation());
+
+    const { result } = renderHook(() => useUploadQueue({ upload, save }));
+    const files = Array.from({ length: 1000 }, (_, i) =>
+      makeFile(`book-${i}.pdf`, 1024 + i, 'application/pdf', i)
+    );
+
+    await act(async () => {
+      result.current.addFiles(files);
+      result.current.start();
+    });
+    await waitFor(() => expect(result.current.summary.isTerminal).toBe(true), { timeout: 10000 });
+
+    expect(peak).toBeLessThanOrEqual(CONCURRENCY);
+    expect(upload).toHaveBeenCalledTimes(1000);
+    expect(save).toHaveBeenCalledTimes(1000);
+    expect(result.current.summary).toMatchObject({
+      total: 1000,
+      succeeded: 1000,
+      failed: 0,
+      cancelled: 0,
+      queued: 0,
+      uploading: 0,
+      saving: 0,
+      isTerminal: true,
+    });
+    expect(result.current.isRunning).toBe(false);
+  });
+
+  it('ignores a second start while the queue is running', async () => {
+    const gate = deferred<CloudinaryAsset>();
+    const upload = vi.fn(() => gate.promise);
+    const save = vi.fn((): SaveOperation => saveOperation());
+
+    const { result } = renderHook(() => useUploadQueue({ upload, save }));
+    await act(async () => {
+      result.current.addFiles([makeFile('a.pdf'), makeFile('b.pdf')]);
+      result.current.start();
+    });
+    expect(upload).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      result.current.start();
+    });
+    expect(upload).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      gate.resolve(asset);
+    });
+    await waitFor(() => expect(result.current.summary.isTerminal).toBe(true));
+    expect(upload).toHaveBeenCalledTimes(2);
+    expect(save).toHaveBeenCalledTimes(2);
+  });
+
+  it('start() while paused is a no-op and does not mark the queue running', () => {
+    const upload = vi.fn(async (): Promise<CloudinaryAsset> => asset);
+    const save = vi.fn((): SaveOperation => saveOperation());
+    const { result } = renderHook(() => useUploadQueue({ upload, save }));
+
+    act(() => {
+      result.current.addFiles([makeFile('a.pdf')]);
+      result.current.pause();
+    });
+    act(() => {
+      result.current.start();
+    });
+
+    expect(result.current.isRunning).toBe(false);
+    expect(result.current.isPaused).toBe(true);
+    expect(upload).not.toHaveBeenCalled();
+  });
+
+  it('rejects duplicate, unsupported, empty, oversized, and over-limit files', () => {
+    const upload = vi.fn(async (): Promise<CloudinaryAsset> => asset);
+    const save = vi.fn((): SaveOperation => saveOperation());
+    const { result } = renderHook(() => useUploadQueue({ upload, save }));
+
+    let rejected!: BatchSummary;
+    act(() => {
+      rejected = result.current.addFiles([
+        makeFile('book.pdf', 1024),
+        makeFile('book.pdf', 1024),
+        makeFile(
+          'notes.docx',
+          1024,
+          'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+        ),
+        makeFile('empty.pdf', 0, 'application/pdf'),
+        makeFile('huge.pdf', MAX_FILE_SIZE + 1),
+      ]);
+    });
+    expect(rejected.accepted).toBe(1);
+    expect(rejected.rejected.map((r) => r.code)).toEqual([
+      'duplicate',
+      'invalid-type',
+      'empty',
+      'too-large',
+    ]);
+
+    let overLimit!: BatchSummary;
+    act(() => {
+      overLimit = result.current.addFiles(
+        Array.from({ length: MAX_FILES }, (_, i) =>
+          makeFile(`bulk-${i}.pdf`, 2048 + i, 'application/pdf', i)
+        )
+      );
+    });
+    expect(overLimit.accepted).toBe(MAX_FILES - 1);
+    expect(overLimit.rejected.map((r) => r.code)).toEqual(['too-many']);
+    expect(result.current.items).toHaveLength(MAX_FILES);
+  });
+
+  it('blocks a fourth upload while paused with 3 active and drains on resume', async () => {
+    const gates = Array.from({ length: 3 }, () => deferred<CloudinaryAsset>());
+    let calls = 0;
+    const upload = vi.fn(() => {
+      const index = calls;
+      calls += 1;
+      return index < 3 ? gates[index].promise : Promise.resolve(asset);
+    });
+    const save = vi.fn((): SaveOperation => saveOperation());
+
+    const { result } = renderHook(() => useUploadQueue({ upload, save }));
+    const files = Array.from({ length: 6 }, (_, i) =>
+      makeFile(`file-${i}.pdf`, 1024, 'application/pdf', i)
+    );
+
+    await act(async () => {
+      result.current.addFiles(files);
+      result.current.start();
+    });
+    expect(upload).toHaveBeenCalledTimes(3);
+
+    act(() => {
+      result.current.pause();
+    });
+    await act(async () => {
+      gates[0].resolve(asset);
+      gates[1].resolve(asset);
+      gates[2].resolve(asset);
+    });
+
+    expect(upload).toHaveBeenCalledTimes(3);
+    expect(save).toHaveBeenCalledTimes(3);
+    expect(result.current.summary.succeeded).toBe(3);
+    expect(result.current.items.filter((i) => i.status === 'queued')).toHaveLength(3);
+
+    act(() => {
+      result.current.resume();
+    });
+    await waitFor(() => expect(result.current.summary.isTerminal).toBe(true));
+    expect(upload).toHaveBeenCalledTimes(6);
+    expect(result.current.summary.succeeded).toBe(6);
+  });
+
+  it('cancel queued never uploads and cancel active aborts its upload', async () => {
+    const signals: AbortSignal[] = [];
+    const uploadedNames: string[] = [];
+    const upload = vi.fn((file: File, signal: AbortSignal) => {
+      uploadedNames.push(file.name);
+      signals.push(signal);
+      const gate = deferred<CloudinaryAsset>();
+      signal.addEventListener('abort', () =>
+        gate.reject(new DOMException('Aborted', 'AbortError'))
+      );
+      return gate.promise;
+    });
+    const save = vi.fn((): SaveOperation => saveOperation());
+
+    const { result } = renderHook(() => useUploadQueue({ upload, save }));
+    await act(async () => {
+      result.current.addFiles(
+        ['a.pdf', 'b.pdf', 'c.pdf', 'd.pdf', 'e.pdf'].map((name) => makeFile(name))
+      );
+      result.current.start();
+    });
+    expect(uploadedNames).toEqual(['a.pdf', 'b.pdf', 'c.pdf']);
+
+    const itemA = result.current.items.find((i) => i.file.name === 'a.pdf');
+    const itemD = result.current.items.find((i) => i.file.name === 'd.pdf');
+    if (!itemA || !itemD) throw new Error('Expected queued test items');
+
+    act(() => {
+      result.current.cancel(itemD.id);
+      result.current.cancel(itemA.id);
+    });
+    await act(async () => {});
+
+    expect(signals[0].aborted).toBe(true);
+    expect(uploadedNames).not.toContain('d.pdf');
+    expect(uploadedNames).toContain('e.pdf');
+    expect(result.current.items.find((i) => i.file.name === 'a.pdf')?.status).toBe('cancelled');
+    expect(result.current.items.find((i) => i.file.name === 'd.pdf')?.status).toBe('cancelled');
+  });
+
+  it('retry after a save failure reuses the cached asset without re-uploading', async () => {
+    let saveCalls = 0;
+    const upload = vi.fn(async (): Promise<CloudinaryAsset> => asset);
+    const save = vi.fn((): SaveOperation => {
+      saveCalls += 1;
+      if (saveCalls === 1) return saveOperation(Promise.reject(new Error('save failed')));
+      return saveOperation();
+    });
+
+    const { result } = renderHook(() => useUploadQueue({ upload, save }));
+    await act(async () => {
+      result.current.addFiles([makeFile('a.pdf')]);
+      result.current.start();
+    });
+
+    await waitFor(() => expect(result.current.items[0].status).toBe('failed'));
+    expect(result.current.items[0].error).toBe('save failed');
+    expect(result.current.items[0].asset).toBe(asset);
+    expect(upload).toHaveBeenCalledTimes(1);
+    expect(save).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.retry(result.current.items[0].id);
+    });
+    await waitFor(() => expect(result.current.items[0].status).toBe('succeeded'));
+    expect(upload).toHaveBeenCalledTimes(1);
+    expect(save).toHaveBeenCalledTimes(2);
+    expect(result.current.summary.isTerminal).toBe(true);
+  });
+
+  it('ignores a same-tick cancel+retry of an upload until the attempt settles, then retries', async () => {
+    let calls = 0;
+    const upload = vi.fn((_file: File, signal: AbortSignal) => {
+      calls += 1;
+      if (calls > 1) return Promise.resolve(asset);
+      const gate = deferred<CloudinaryAsset>();
+      signal.addEventListener('abort', () =>
+        gate.reject(new DOMException('Aborted', 'AbortError'))
+      );
+      return gate.promise;
+    });
+    const save = vi.fn((): SaveOperation => saveOperation());
+
+    const { result } = renderHook(() => useUploadQueue({ upload, save }));
+    await act(async () => {
+      result.current.addFiles([makeFile('a.pdf')]);
+      result.current.start();
+    });
+    expect(result.current.items[0].status).toBe('uploading');
+
+    act(() => {
+      result.current.cancel(result.current.items[0].id);
+      result.current.retry(result.current.items[0].id);
+    });
+    // The same-tick retry is ignored while the upload controller is still winding down.
+    expect(result.current.items[0].status).toBe('cancelled');
+    expect(upload).toHaveBeenCalledTimes(1);
+
+    await act(async () => {});
+    act(() => {
+      result.current.retry(result.current.items[0].id);
+    });
+    await waitFor(() => expect(result.current.items[0].status).toBe('succeeded'));
+    expect(upload).toHaveBeenCalledTimes(2);
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(result.current.summary.isTerminal).toBe(true);
+  });
+
+  it('retries one failed item without starting other queued files while the queue is stopped', async () => {
+    let aPdfSaveCalls = 0;
+    const upload = vi.fn(async (): Promise<CloudinaryAsset> => asset);
+    const save = vi.fn((item: UploadItem): SaveOperation => {
+      if (item.file.name === 'a.pdf') {
+        aPdfSaveCalls += 1;
+        if (aPdfSaveCalls === 1) return saveOperation(Promise.reject(new Error('save failed')));
+      }
+      return saveOperation();
+    });
+
+    const { result } = renderHook(() => useUploadQueue({ upload, save }));
+    await act(async () => {
+      result.current.addFiles(['a.pdf', 'b.pdf', 'c.pdf'].map((name) => makeFile(name)));
+      result.current.start();
+    });
+    await waitFor(() => expect(result.current.summary.isTerminal).toBe(true));
+    expect(result.current.items.find((i) => i.file.name === 'a.pdf')?.status).toBe('failed');
+
+    act(() => {
+      result.current.addFiles(['d.pdf', 'e.pdf'].map((name) => makeFile(name)));
+    });
+    expect(result.current.items.filter((i) => i.status === 'queued')).toHaveLength(2);
+
+    act(() => {
+      const itemA = result.current.items.find((i) => i.file.name === 'a.pdf');
+      if (!itemA) throw new Error('Expected failed test item');
+      result.current.retry(itemA.id);
+    });
+    await waitFor(() =>
+      expect(result.current.items.find((i) => i.file.name === 'a.pdf')?.status).toBe('succeeded')
+    );
+
+    // Only a.pdf was re-run; the newly queued files stay queued.
+    expect(upload).toHaveBeenCalledTimes(3);
+    expect(save).toHaveBeenCalledTimes(4);
+    expect(result.current.items.filter((i) => i.status === 'queued')).toHaveLength(2);
+    expect(result.current.items.filter((i) => i.status === 'uploading')).toHaveLength(0);
+    expect(result.current.items.filter((i) => i.status === 'saving')).toHaveLength(0);
+    expect(result.current.isRunning).toBe(false);
+  });
+
+  it('stops running when the last active item settles while paused', async () => {
+    const gate = deferred<CloudinaryAsset>();
+    const upload = vi.fn(() => gate.promise);
+    const save = vi.fn((): SaveOperation => saveOperation());
+
+    const { result } = renderHook(() => useUploadQueue({ upload, save }));
+    await act(async () => {
+      result.current.addFiles([makeFile('a.pdf')]);
+      result.current.start();
+    });
+    expect(result.current.isRunning).toBe(true);
+    expect(result.current.items[0].status).toBe('uploading');
+
+    act(() => {
+      result.current.pause();
+    });
+    expect(result.current.isPaused).toBe(true);
+
+    await act(async () => {
+      gate.resolve(asset);
+    });
+    await waitFor(() => expect(result.current.isRunning).toBe(false));
+    expect(result.current.isPaused).toBe(true);
+    expect(result.current.summary.isTerminal).toBe(true);
+  });
+
+  it('retry is a no-op while paused and only runs after resume', async () => {
+    let saveCalls = 0;
+    const upload = vi.fn(async (): Promise<CloudinaryAsset> => asset);
+    const save = vi.fn((): SaveOperation => {
+      saveCalls += 1;
+      if (saveCalls === 1) return saveOperation(Promise.reject(new Error('save failed')));
+      return saveOperation();
+    });
+
+    const { result } = renderHook(() => useUploadQueue({ upload, save }));
+    await act(async () => {
+      result.current.addFiles([makeFile('a.pdf')]);
+      result.current.start();
+    });
+    await waitFor(() => expect(result.current.items[0].status).toBe('failed'));
+    expect(result.current.isRunning).toBe(false);
+
+    act(() => {
+      result.current.pause();
+      result.current.retry(result.current.items[0].id);
+    });
+    // While paused the stopped-path retry is a no-op: the item stays failed.
+    expect(result.current.items[0].status).toBe('failed');
+    expect(result.current.isPaused).toBe(true);
+    expect(upload).toHaveBeenCalledTimes(1);
+    expect(save).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      result.current.resume();
+      result.current.retry(result.current.items[0].id);
+    });
+    await waitFor(() => expect(result.current.items[0].status).toBe('succeeded'));
+    expect(upload).toHaveBeenCalledTimes(1);
+    expect(save).toHaveBeenCalledTimes(2);
+  });
+});

--- a/client/src/hooks/uploadQueueState.ts
+++ b/client/src/hooks/uploadQueueState.ts
@@ -1,0 +1,179 @@
+import type { CloudinaryAsset } from '../services/cloudinaryUpload';
+
+export const UPLOAD_CONCURRENCY = 3;
+export const MAX_UPLOAD_FILES = 1000;
+export const MAX_UPLOAD_FILE_SIZE = 100 * 1024 * 1024;
+
+export type UploadStatus = 'queued' | 'uploading' | 'saving' | 'succeeded' | 'failed' | 'cancelled';
+
+export type RejectionCode = 'invalid-type' | 'too-large' | 'too-many' | 'duplicate' | 'empty';
+
+export interface UploadItem {
+  id: string;
+  file: File;
+  status: UploadStatus;
+  progress: number;
+  error?: string;
+  asset?: CloudinaryAsset;
+}
+
+export interface UploadQueueState {
+  items: UploadItem[];
+  isPaused: boolean;
+}
+
+export interface QueueRejection {
+  file: File;
+  reason: string;
+  code: RejectionCode;
+}
+
+export interface AddFilesResult {
+  accepted: UploadItem[];
+  rejected: QueueRejection[];
+}
+
+export interface UploadQueueSummary {
+  total: number;
+  queued: number;
+  uploading: number;
+  saving: number;
+  succeeded: number;
+  failed: number;
+  cancelled: number;
+  isTerminal: boolean;
+}
+
+export type UploadQueueAction =
+  | { type: 'add'; items: UploadItem[] }
+  | { type: 'patchItem'; id: string; patch: Partial<UploadItem> }
+  | { type: 'remove'; id: string }
+  | { type: 'pause' }
+  | { type: 'resume' };
+
+export function uploadQueueReducer(
+  state: UploadQueueState,
+  action: UploadQueueAction
+): UploadQueueState {
+  switch (action.type) {
+    case 'add':
+      return { ...state, items: [...state.items, ...action.items] };
+    case 'patchItem':
+      return {
+        ...state,
+        items: state.items.map((item) =>
+          item.id === action.id ? { ...item, ...action.patch } : item
+        ),
+      };
+    case 'remove':
+      return { ...state, items: state.items.filter((item) => item.id !== action.id) };
+    case 'pause':
+      return { ...state, isPaused: true };
+    case 'resume':
+      return { ...state, isPaused: false };
+  }
+}
+
+let fallbackIdCounter = 0;
+function createStableId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  fallbackIdCounter += 1;
+  return `upload-${fallbackIdCounter}`;
+}
+
+function getExtension(name: string): string {
+  const dot = name.lastIndexOf('.');
+  return dot === -1 ? '' : name.slice(dot + 1).toLowerCase();
+}
+
+function isSupportedFile(file: File): boolean {
+  const mime = file.type.toLowerCase();
+  const extension = getExtension(file.name);
+  return (
+    mime === 'application/pdf' ||
+    mime === 'application/epub+zip' ||
+    extension === 'pdf' ||
+    extension === 'epub'
+  );
+}
+
+function fileKey(name: string, size: number, lastModified: number): string {
+  return `${name}:${size}:${lastModified}`;
+}
+
+function reject(rejected: QueueRejection[], file: File, code: RejectionCode, reason: string): void {
+  rejected.push({ file, reason, code });
+}
+
+export function validateFiles(existingItems: UploadItem[], files: File[]): AddFilesResult {
+  const accepted: UploadItem[] = [];
+  const rejected: QueueRejection[] = [];
+  const seen = new Set<string>();
+  let count = 0;
+
+  for (const item of existingItems) {
+    if (item.status === 'cancelled') continue;
+    seen.add(fileKey(item.file.name, item.file.size, item.file.lastModified));
+    count += 1;
+  }
+
+  for (const file of files) {
+    if (!isSupportedFile(file)) {
+      reject(rejected, file, 'invalid-type', 'Only PDF and EPUB files are supported');
+      continue;
+    }
+    if (file.size <= 0) {
+      reject(rejected, file, 'empty', 'File is empty');
+      continue;
+    }
+    if (file.size > MAX_UPLOAD_FILE_SIZE) {
+      reject(rejected, file, 'too-large', 'File exceeds the 100 MB limit');
+      continue;
+    }
+    if (count >= MAX_UPLOAD_FILES) {
+      reject(rejected, file, 'too-many', `Upload queue is limited to ${MAX_UPLOAD_FILES} files`);
+      continue;
+    }
+    const key = fileKey(file.name, file.size, file.lastModified);
+    if (seen.has(key)) {
+      reject(
+        rejected,
+        file,
+        'duplicate',
+        'A file with the same name, size and modified time is already queued'
+      );
+      continue;
+    }
+    seen.add(key);
+    count += 1;
+    accepted.push({
+      id: createStableId(),
+      file,
+      status: 'queued',
+      progress: 0,
+    });
+  }
+
+  return { accepted, rejected };
+}
+
+export function getBatchSummary(items: UploadItem[]): UploadQueueSummary {
+  const summary: UploadQueueSummary = {
+    total: items.length,
+    queued: 0,
+    uploading: 0,
+    saving: 0,
+    succeeded: 0,
+    failed: 0,
+    cancelled: 0,
+    isTerminal: false,
+  };
+  for (const item of items) {
+    summary[item.status] += 1;
+  }
+  const completed = summary.succeeded + summary.failed + summary.cancelled;
+  summary.isTerminal = summary.total > 0 && completed === summary.total;
+  return summary;
+}

--- a/client/src/hooks/useUploadQueue.ts
+++ b/client/src/hooks/useUploadQueue.ts
@@ -1,0 +1,245 @@
+import { useCallback, useMemo, useReducer, useRef, useState } from 'react';
+import type { CloudinaryAsset } from '../services/cloudinaryUpload';
+import type {
+  QueueRejection,
+  UploadItem,
+  UploadQueueAction,
+  UploadQueueSummary,
+} from './uploadQueueState';
+import {
+  getBatchSummary,
+  UPLOAD_CONCURRENCY,
+  uploadQueueReducer,
+  validateFiles,
+} from './uploadQueueState';
+
+export type {
+  QueueRejection,
+  RejectionCode as RejectionReason,
+  UploadItem,
+  UploadQueueSummary,
+  UploadStatus,
+} from './uploadQueueState';
+export {
+  MAX_UPLOAD_FILE_SIZE as MAX_FILE_SIZE,
+  MAX_UPLOAD_FILES as MAX_FILES,
+  UPLOAD_CONCURRENCY as CONCURRENCY,
+} from './uploadQueueState';
+
+export interface SaveOperation {
+  promise: Promise<void>;
+}
+
+export interface BatchSummary {
+  accepted: number;
+  rejected: QueueRejection[];
+}
+
+export interface UseUploadQueueOptions {
+  upload: (
+    file: File,
+    signal: AbortSignal,
+    onProgress: (percent: number) => void
+  ) => Promise<CloudinaryAsset>;
+  save: (item: UploadItem, asset: CloudinaryAsset) => SaveOperation;
+}
+
+export interface UseUploadQueueResult {
+  items: UploadItem[];
+  addFiles: (files: File[]) => BatchSummary;
+  start: () => void;
+  pause: () => void;
+  resume: () => void;
+  cancel: (id: string) => void;
+  cancelAll: () => void;
+  remove: (id: string) => void;
+  retry: (id: string) => void;
+  isRunning: boolean;
+  isPaused: boolean;
+  summary: UploadQueueSummary;
+}
+
+function conciseError(error: unknown): string {
+  return error instanceof Error && error.message ? error.message : 'Upload failed';
+}
+
+export function useUploadQueue(options: UseUploadQueueOptions): UseUploadQueueResult {
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+  const [state, dispatch] = useReducer(uploadQueueReducer, { items: [], isPaused: false });
+  const stateRef = useRef(state);
+
+  const commit = useCallback((action: UploadQueueAction) => {
+    stateRef.current = uploadQueueReducer(stateRef.current, action);
+    dispatch(action);
+  }, []);
+  const patch = useCallback(
+    (id: string, patch: Partial<UploadItem>) => commit({ type: 'patchItem', id, patch }),
+    [commit]
+  );
+  const [isRunning, setIsRunning] = useState(false);
+  const runningRef = useRef(false);
+  const controllersRef = useRef(new Map<string, AbortController>());
+  const activeRef = useRef(0);
+  const pumpRef = useRef<() => void>(() => {});
+  const runItemRef = useRef<(id: string) => void>(() => {});
+  const runItem = useCallback(
+    async (id: string) => {
+      const current = () => stateRef.current.items.find((entry) => entry.id === id);
+      try {
+        let item = current();
+        if (!item) return;
+        if (item.asset) patch(id, { status: 'saving' });
+        else {
+          patch(id, { status: 'uploading' });
+          const controller = new AbortController();
+          controllersRef.current.set(id, controller);
+          try {
+            const onProgress = (percent: number) => {
+              const rounded = Math.round(percent);
+              if (current()?.progress !== rounded) {
+                patch(id, { progress: rounded });
+              }
+            };
+            const asset = await optionsRef.current.upload(item.file, controller.signal, onProgress);
+            if (current()?.status !== 'cancelled') {
+              patch(id, { status: 'saving', asset, progress: 100 });
+            }
+          } catch (error) {
+            if (current()?.status !== 'cancelled') {
+              patch(id, { status: 'failed', error: conciseError(error) });
+            }
+            return;
+          } finally {
+            controllersRef.current.delete(id);
+          }
+        }
+        item = current();
+        if (!item || item.status === 'cancelled' || !item.asset) return;
+        try {
+          const operation = optionsRef.current.save(item, item.asset);
+          await operation.promise;
+          patch(id, { status: 'succeeded', progress: 100 });
+        } catch (error) {
+          patch(id, { status: 'failed', error: conciseError(error) });
+        }
+      } finally {
+        activeRef.current = Math.max(0, activeRef.current - 1);
+        pumpRef.current();
+      }
+    },
+    [patch]
+  );
+  const pump = useCallback(() => {
+    if (!runningRef.current) return;
+    // Settle `running` even while paused: once the active items finish (and
+    // nothing is queued), the queue is no longer running. The paused check is
+    // done below so a queue paused with only in-flight items stops cleanly.
+    if (activeRef.current === 0 && !stateRef.current.items.some((e) => e.status === 'queued')) {
+      runningRef.current = false;
+      setIsRunning(false);
+    }
+    if (stateRef.current.isPaused) return;
+    while (activeRef.current < UPLOAD_CONCURRENCY) {
+      const next = stateRef.current.items.find((entry) => entry.status === 'queued');
+      if (!next) break;
+      activeRef.current += 1;
+      void runItemRef.current(next.id);
+    }
+  }, []);
+  pumpRef.current = pump;
+  runItemRef.current = runItem;
+  const addFiles = useCallback(
+    (files: File[]) => {
+      const result = validateFiles(stateRef.current.items, files);
+      if (result.accepted.length > 0) commit({ type: 'add', items: result.accepted });
+      if (runningRef.current) pumpRef.current();
+      return { accepted: result.accepted.length, rejected: result.rejected };
+    },
+    [commit]
+  );
+  const start = useCallback(() => {
+    if (runningRef.current || stateRef.current.isPaused) return;
+    runningRef.current = true;
+    setIsRunning(true);
+    pumpRef.current();
+  }, []);
+  const pause = useCallback(() => commit({ type: 'pause' }), [commit]);
+  const resume = useCallback(() => {
+    commit({ type: 'resume' });
+    if (runningRef.current) pumpRef.current();
+  }, [commit]);
+  const cancel = useCallback(
+    (id: string) => {
+      const item = stateRef.current.items.find((entry) => entry.id === id);
+      if (!item) return;
+      if (item.status === 'queued' || item.status === 'uploading') {
+        patch(id, { status: 'cancelled' });
+      }
+      if (item.status === 'uploading') {
+        controllersRef.current.get(id)?.abort();
+      }
+    },
+    [patch]
+  );
+  const cancelAll = useCallback(() => {
+    for (const entry of stateRef.current.items) {
+      if (entry.status === 'uploading') {
+        patch(entry.id, { status: 'cancelled' });
+        controllersRef.current.get(entry.id)?.abort();
+      } else if (entry.status === 'queued') {
+        patch(entry.id, { status: 'cancelled' });
+      }
+    }
+    pumpRef.current();
+  }, [patch]);
+  const remove = useCallback(
+    (id: string) => {
+      const item = stateRef.current.items.find((entry) => entry.id === id);
+      if (!item || item.status === 'uploading' || item.status === 'saving') return;
+      controllersRef.current.delete(id);
+      commit({ type: 'remove', id });
+      pumpRef.current();
+    },
+    [commit]
+  );
+  const retry = useCallback(
+    (id: string) => {
+      const item = stateRef.current.items.find((entry) => entry.id === id);
+      if (!item || (item.status !== 'failed' && item.status !== 'cancelled')) return;
+      // No-op while the previous attempt is still winding down: its upload
+      // controller is only removed in that attempt's `finally`, so a cancel
+      // followed by a same-tick retry must not race it.
+      if (controllersRef.current.has(id)) return;
+      // No-op while paused: nothing may start until the queue is resumed.
+      if (stateRef.current.isPaused) return;
+      patch(id, { status: 'queued', progress: item.asset ? item.progress : 0, error: undefined });
+      // Whole queue already running: the normal pump picks the item up.
+      if (runningRef.current) {
+        pumpRef.current();
+        return;
+      }
+      // Queue stopped: run just this item. The running flag stays off so the
+      // pump (called when the attempt settles) will not start other queued
+      // files; active accounting is still shared with a later full start.
+      activeRef.current += 1;
+      void runItemRef.current(id);
+    },
+    [patch]
+  );
+  const summary = useMemo(() => getBatchSummary(state.items), [state.items]);
+  return {
+    items: state.items,
+    addFiles,
+    start,
+    pause,
+    resume,
+    cancel,
+    cancelAll,
+    remove,
+    retry,
+    isRunning,
+    isPaused: state.isPaused,
+    summary,
+  };
+}

--- a/client/src/pages/UploadNewBook.tsx
+++ b/client/src/pages/UploadNewBook.tsx
@@ -1,4 +1,4 @@
-import { AlertCircle, Book, CheckCircle, FileText, Upload, X } from 'lucide-react';
+import { AlertCircle, Book, CheckCircle, FileText, Upload, X, XCircle } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { toast } from 'sonner';
@@ -17,15 +17,15 @@ import {
   Progress,
 } from '@/components/ui';
 import Layout from '../components/Layout';
+import {
+  type QueueRejection,
+  type SaveOperation,
+  type UploadItem,
+  useUploadQueue,
+} from '../hooks/useUploadQueue';
 import { useAddNewBookMutation } from '../redux/services/book.api';
-
-interface UploadFile {
-  file: File;
-  id: string;
-  status: 'pending' | 'uploading' | 'success' | 'error';
-  progress: number;
-  error?: string;
-}
+import type { CloudinaryAsset } from '../services/cloudinaryUpload';
+import { uploadToCloudinary } from '../services/cloudinaryUpload';
 
 interface ManualMetadata {
   author: string;
@@ -39,158 +39,178 @@ const emptyManualMetadata: ManualMetadata = {
   publisher: '',
 };
 
+const statusLabels: Record<UploadItem['status'], string> = {
+  queued: 'Queued for upload',
+  uploading: 'Uploading...',
+  saving: 'Saving to library...',
+  succeeded: 'Uploaded successfully!',
+  failed: 'Upload failed',
+  cancelled: 'Upload cancelled',
+};
+
+const formatFileSize = (bytes: number) => {
+  if (bytes === 0) return '0 Bytes';
+  const k = 1024;
+  const sizes = ['Bytes', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${parseFloat((bytes / k ** i).toFixed(2))} ${sizes[i]}`;
+};
+
+const getStatusIcon = (status: UploadItem['status']) => {
+  switch (status) {
+    case 'succeeded':
+      return <CheckCircle className="h-5 w-5 text-green-500" />;
+    case 'failed':
+      return <AlertCircle className="h-5 w-5 text-red-500" />;
+    case 'uploading':
+    case 'saving':
+      return (
+        <div className="h-5 w-5 border-2 border-primary border-t-transparent rounded-full animate-spin" />
+      );
+    case 'cancelled':
+      return <XCircle className="h-5 w-5 text-gray-400" />;
+    default:
+      return <FileText className="h-5 w-5 text-gray-400" />;
+  }
+};
+
+const summarizeRejections = (rejected: QueueRejection[]): string => {
+  const counts = new Map<string, number>();
+  for (const { reason } of rejected) {
+    counts.set(reason, (counts.get(reason) ?? 0) + 1);
+  }
+  const parts: string[] = [];
+  for (const [reason, count] of counts) {
+    parts.push(count > 1 ? `${reason} (${count})` : reason);
+  }
+  return parts.join(', ');
+};
+
+const editableItemsOf = (entries: UploadItem[]) =>
+  entries.filter((entry) => entry.status !== 'succeeded' && entry.status !== 'cancelled');
+
 export default function UploadNewBook() {
-  const [uploadFiles, setUploadFiles] = useState<UploadFile[]>([]);
   const [manualMetadata, setManualMetadata] = useState<ManualMetadata>(emptyManualMetadata);
-  const metadataFileIdRef = useRef<string | undefined>(undefined);
+  const manualMetadataRef = useRef<ManualMetadata>(emptyManualMetadata);
+  const metadataItemIdRef = useRef<string | undefined>(undefined);
+  const itemsRef = useRef<UploadItem[]>([]);
+  const prevTerminalRef = useRef(false);
   const [addNewBook] = useAddNewBookMutation();
 
-  const uploadToCloudinary = async (file: File): Promise<any> => {
-    const formData = new FormData();
-    formData.append('file', file);
-    formData.append('upload_preset', 'unsigned_upload'); // You may need to configure this
+  const save = useCallback(
+    (item: UploadItem, asset: CloudinaryAsset): SaveOperation => {
+      // Metadata is owned by a single item id, read from refs so a later file
+      // added to the queue cannot detach these values from their owner.
+      const withMetadata = metadataItemIdRef.current === item.id;
+      const metadata = withMetadata ? manualMetadataRef.current : emptyManualMetadata;
+      const author = metadata.author.trim();
+      const isbn = metadata.isbn.trim();
+      const publisher = metadata.publisher.trim();
 
-    const response = await fetch(import.meta.env.VITE_CLOUDINARY_URL as string, {
-      method: 'POST',
-      body: formData,
+      const book = {
+        name: item.file.name,
+        size: String(asset.bytes),
+        url: asset.secure_url,
+        ...(author ? { author } : null),
+        ...(isbn ? { isbn } : null),
+        ...(publisher ? { publisher } : null),
+      };
+
+      const request = addNewBook(book);
+      return { promise: request.unwrap().then(() => undefined) };
+    },
+    [addNewBook]
+  );
+
+  const {
+    items,
+    addFiles,
+    start,
+    pause,
+    resume,
+    cancel,
+    cancelAll,
+    remove,
+    retry,
+    isRunning,
+    isPaused,
+    summary,
+  } = useUploadQueue({ upload: uploadToCloudinary, save });
+
+  itemsRef.current = items;
+
+  const editable = editableItemsOf(items);
+  const metadataTargetId = editable.length === 1 ? editable[0].id : undefined;
+
+  const updateManualMetadata = useCallback((patch: Partial<ManualMetadata>) => {
+    setManualMetadata((current) => {
+      const next = { ...current, ...patch };
+      manualMetadataRef.current = next;
+      return next;
     });
-
-    if (!response.ok) {
-      throw new Error('Upload failed');
-    }
-
-    return response.json();
-  };
-
-  const addBook = async (response: any, originalFile: File, metadata?: ManualMetadata) => {
-    const book = {
-      name: originalFile.name,
-      size: response.bytes,
-      url: response.secure_url,
-      ...(metadata?.author.trim() && { author: metadata.author.trim() }),
-      ...(metadata?.isbn.trim() && { isbn: metadata.isbn.trim() }),
-      ...(metadata?.publisher.trim() && {
-        publisher: metadata.publisher.trim(),
-      }),
-    };
-
-    await addNewBook(book).unwrap();
-    return book;
-  };
-
-  const handleFileUpload = async (fileItem: UploadFile) => {
-    const metadataForBook =
-      uploadFiles.length === 1 &&
-      uploadFiles[0].id === fileItem.id &&
-      metadataFileIdRef.current === fileItem.id
-        ? { ...manualMetadata }
-        : undefined;
-    let progressInterval: ReturnType<typeof setInterval> | undefined;
-
-    try {
-      // Update status to uploading
-      setUploadFiles((prev) =>
-        prev.map((f) => (f.id === fileItem.id ? { ...f, status: 'uploading', progress: 0 } : f))
-      );
-
-      // Simulate progress (you can implement real progress tracking)
-      progressInterval = setInterval(() => {
-        setUploadFiles((prev) =>
-          prev.map((f) =>
-            f.id === fileItem.id && f.progress < 90 ? { ...f, progress: f.progress + 10 } : f
-          )
-        );
-      }, 200);
-
-      // Upload to Cloudinary
-      const cloudinaryResponse = await uploadToCloudinary(fileItem.file);
-
-      // Add to database
-      const book = await addBook(cloudinaryResponse, fileItem.file, metadataForBook);
-
-      // Update status to success
-      setUploadFiles((prev) =>
-        prev.map((f) => (f.id === fileItem.id ? { ...f, status: 'success', progress: 100 } : f))
-      );
-
-      toast.success(`${book.name} has been uploaded successfully!`);
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Upload failed';
-
-      setUploadFiles((prev) =>
-        prev.map((f) => (f.id === fileItem.id ? { ...f, status: 'error', error: errorMessage } : f))
-      );
-
-      toast.error(`Upload failed: ${errorMessage}`);
-    } finally {
-      if (progressInterval !== undefined) {
-        clearInterval(progressInterval);
-      }
-    }
-  };
-
-  const onDrop = useCallback((acceptedFiles: File[]) => {
-    const newFiles: UploadFile[] = acceptedFiles.map((file) => ({
-      file,
-      id: Math.random().toString(36).substr(2, 9),
-      status: 'pending',
-      progress: 0,
-    }));
-
-    setUploadFiles((prev) => [...prev, ...newFiles]);
   }, []);
 
-  const removeFile = (id: string) => {
-    setUploadFiles((prev) => prev.filter((f) => f.id !== id));
-  };
-
   useEffect(() => {
-    const nextMetadataFileId = uploadFiles.length === 1 ? uploadFiles[0].id : undefined;
-
-    if (metadataFileIdRef.current !== nextMetadataFileId) {
-      metadataFileIdRef.current = nextMetadataFileId;
+    if (metadataTargetId === undefined || metadataItemIdRef.current === metadataTargetId) {
+      return;
+    }
+    // Only hand the metadata form to a new item once its previous owner is no
+    // longer editable (removed or terminal). Adding another file merely hides
+    // the panel and must not reset the in-flight owner's values.
+    const ownerId = metadataItemIdRef.current;
+    const owner =
+      ownerId === undefined ? undefined : itemsRef.current.find((entry) => entry.id === ownerId);
+    const ownerGone =
+      ownerId === undefined ||
+      owner === undefined ||
+      owner.status === 'succeeded' ||
+      owner.status === 'cancelled';
+    if (ownerGone) {
+      metadataItemIdRef.current = metadataTargetId;
+      manualMetadataRef.current = emptyManualMetadata;
       setManualMetadata(emptyManualMetadata);
     }
-  }, [uploadFiles]);
+  }, [metadataTargetId]);
 
-  const uploadAll = () => {
-    uploadFiles.filter((f) => f.status === 'pending').forEach(handleFileUpload);
-  };
-
-  const { getRootProps, getInputProps, isDragActive } = useDropzone({
-    onDrop,
-    accept: {
-      'application/pdf': ['.pdf'],
-      'application/epub+zip': ['.epub'],
-    },
-    multiple: true,
-  });
-
-  const formatFileSize = (bytes: number) => {
-    if (bytes === 0) return '0 Bytes';
-    const k = 1024;
-    const sizes = ['Bytes', 'KB', 'MB', 'GB'];
-    const i = Math.floor(Math.log(bytes) / Math.log(k));
-    return parseFloat((bytes / k ** i).toFixed(2)) + ' ' + sizes[i];
-  };
-
-  const getStatusIcon = (status: UploadFile['status']) => {
-    switch (status) {
-      case 'success':
-        return <CheckCircle className="h-5 w-5 text-green-500" />;
-      case 'error':
-        return <AlertCircle className="h-5 w-5 text-red-500" />;
-      case 'uploading':
-        return (
-          <div className="h-5 w-5 border-2 border-primary border-t-transparent rounded-full animate-spin" />
-        );
-      default:
-        return <FileText className="h-5 w-5 text-gray-400" />;
+  useEffect(() => {
+    if (summary.isTerminal && !prevTerminalRef.current) {
+      if (summary.succeeded > 0 || summary.failed > 0) {
+        const parts = [
+          `${summary.succeeded} uploaded`,
+          `${summary.failed} failed`,
+          `${summary.cancelled} cancelled`,
+        ].join(', ');
+        if (summary.failed > 0 || summary.cancelled > 0) {
+          toast.error(`Upload batch finished: ${parts}`);
+        } else {
+          toast.success(`Upload batch finished: ${parts}`);
+        }
+      }
     }
-  };
+    prevTerminalRef.current = summary.isTerminal;
+  }, [summary.isTerminal, summary.succeeded, summary.failed, summary.cancelled]);
 
-  const pendingFiles = uploadFiles.filter((f) => f.status === 'pending');
-  const completedFiles = uploadFiles.filter((f) => f.status === 'success');
+  const onDrop = useCallback(
+    (droppedFiles: File[]) => {
+      const result = addFiles(droppedFiles);
+      if (result.rejected.length === 0) return;
+
+      const rejectedText = `${result.rejected.length} file${result.rejected.length === 1 ? '' : 's'} rejected`;
+      const summaryText =
+        result.accepted > 0
+          ? `${result.accepted} file${result.accepted === 1 ? '' : 's'} added, ${rejectedText}`
+          : rejectedText;
+      toast.error(`${summaryText}: ${summarizeRejections(result.rejected)}`);
+    },
+    [addFiles]
+  );
+
+  const { getRootProps, getInputProps, isDragActive, open } = useDropzone({
+    onDrop,
+    multiple: true,
+    noClick: true,
+    noKeyboard: true,
+  });
 
   return (
     <Layout>
@@ -223,13 +243,15 @@ export default function UploadNewBook() {
                 <Book className="h-5 w-5" />
                 Select Files
               </CardTitle>
-              <CardDescription>Drag and drop your books here, or click to browse</CardDescription>
+              <CardDescription>
+                Drag and drop your books here, or use the Browse Files button below
+              </CardDescription>
             </CardHeader>
             <CardContent>
               <div
                 {...getRootProps()}
                 className={`
-                  border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-all duration-200
+                  border-2 border-dashed rounded-lg p-8 text-center transition-all duration-200
                   ${
                     isDragActive
                       ? 'border-primary bg-primary/5 dark:bg-primary/10'
@@ -247,14 +269,14 @@ export default function UploadNewBook() {
                   ) : (
                     <>
                       <p className="text-lg font-medium text-gray-900 dark:text-gray-100">
-                        Choose files or drag and drop
+                        Drag and drop your books here
                       </p>
                       <p className="text-sm text-gray-500 dark:text-gray-400">
                         PDF and EPUB files up to 100MB each
                       </p>
                     </>
                   )}
-                  <Button variant="outline" type="button">
+                  <Button variant="outline" type="button" onClick={open}>
                     Browse Files
                   </Button>
                 </div>
@@ -280,23 +302,44 @@ export default function UploadNewBook() {
           </Card>
 
           {/* File List */}
-          {uploadFiles.length > 0 && (
+          {items.length > 0 && (
             <Card>
               <CardHeader className="flex flex-row items-center justify-between">
                 <div>
                   <CardTitle>Upload Queue</CardTitle>
                   <CardDescription>
-                    {completedFiles.length} of {uploadFiles.length} files uploaded
+                    {summary.succeeded} of {summary.total} files uploaded
+                    {summary.failed > 0 ? ` · ${summary.failed} failed` : ''}
+                    {summary.cancelled > 0 ? ` · ${summary.cancelled} cancelled` : ''}
                   </CardDescription>
                 </div>
-                {pendingFiles.length > 0 && (
-                  <Button onClick={uploadAll} className="ml-4">
-                    Upload All ({pendingFiles.length})
+                <div className="flex items-center gap-2">
+                  {isRunning && !isPaused && (
+                    <Button variant="outline" onClick={pause}>
+                      Pause
+                    </Button>
+                  )}
+                  {isPaused && (
+                    <Button variant="outline" onClick={resume}>
+                      Resume
+                    </Button>
+                  )}
+                  {(summary.queued > 0 || summary.uploading > 0) && (
+                    <Button variant="outline" onClick={cancelAll}>
+                      Cancel All
+                    </Button>
+                  )}
+                  <Button
+                    onClick={start}
+                    disabled={summary.queued === 0 || isRunning || isPaused}
+                    className="ml-4"
+                  >
+                    Upload All{summary.queued > 0 ? ` (${summary.queued})` : ''}
                   </Button>
-                )}
+                </div>
               </CardHeader>
               <CardContent>
-                {uploadFiles.length === 1 && uploadFiles[0].status !== 'success' && (
+                {metadataTargetId !== undefined && (
                   <div className="mb-6 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
                     <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100">
                       Optional book metadata
@@ -310,12 +353,7 @@ export default function UploadNewBook() {
                         <Input
                           id="upload-author"
                           value={manualMetadata.author}
-                          onChange={(event) =>
-                            setManualMetadata((current) => ({
-                              ...current,
-                              author: event.target.value,
-                            }))
-                          }
+                          onChange={(event) => updateManualMetadata({ author: event.target.value })}
                           maxLength={200}
                           autoComplete="off"
                         />
@@ -325,12 +363,7 @@ export default function UploadNewBook() {
                         <Input
                           id="upload-isbn"
                           value={manualMetadata.isbn}
-                          onChange={(event) =>
-                            setManualMetadata((current) => ({
-                              ...current,
-                              isbn: event.target.value,
-                            }))
-                          }
+                          onChange={(event) => updateManualMetadata({ isbn: event.target.value })}
                           maxLength={32}
                           autoComplete="off"
                           inputMode="numeric"
@@ -342,10 +375,7 @@ export default function UploadNewBook() {
                           id="upload-publisher"
                           value={manualMetadata.publisher}
                           onChange={(event) =>
-                            setManualMetadata((current) => ({
-                              ...current,
-                              publisher: event.target.value,
-                            }))
+                            updateManualMetadata({ publisher: event.target.value })
                           }
                           maxLength={200}
                           autoComplete="off"
@@ -355,68 +385,74 @@ export default function UploadNewBook() {
                   </div>
                 )}
                 <div className="space-y-4">
-                  {uploadFiles.map((fileItem) => (
+                  {items.map((item) => (
                     <div
-                      key={fileItem.id}
+                      key={item.id}
                       className="flex items-center space-x-4 p-4 border border-gray-200 dark:border-gray-700 rounded-lg"
                     >
-                      <div className="flex-shrink-0">{getStatusIcon(fileItem.status)}</div>
+                      <div className="flex-shrink-0">{getStatusIcon(item.status)}</div>
 
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center justify-between mb-1">
                           <p className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
-                            {fileItem.file.name}
+                            {item.file.name}
                           </p>
                           <div className="flex items-center space-x-2">
                             <Badge variant="outline" className="text-xs">
-                              {formatFileSize(fileItem.file.size)}
+                              {formatFileSize(item.file.size)}
                             </Badge>
                             <Badge variant="secondary" className="text-xs">
-                              {fileItem.file.name.split('.').pop()?.toUpperCase()}
+                              {item.file.name.split('.').pop()?.toUpperCase()}
                             </Badge>
                           </div>
                         </div>
 
-                        {fileItem.status === 'uploading' && (
-                          <div className="space-y-2">
-                            <Progress value={fileItem.progress} className="h-2" />
-                            <p className="text-xs text-gray-500">
-                              Uploading... {fileItem.progress}%
-                            </p>
+                        <p
+                          className={`text-xs ${
+                            item.status === 'succeeded'
+                              ? 'text-green-600 dark:text-green-400'
+                              : item.status === 'failed'
+                                ? 'text-red-500'
+                                : 'text-gray-500 dark:text-gray-400'
+                          }`}
+                        >
+                          {statusLabels[item.status]}
+                        </p>
+
+                        {item.status === 'uploading' && (
+                          <div className="mt-2 space-y-2">
+                            <Progress value={item.progress} className="h-2" />
+                            <p className="text-xs text-gray-500">{item.progress}%</p>
                           </div>
                         )}
 
-                        {fileItem.status === 'error' && (
-                          <p className="text-xs text-red-500">Error: {fileItem.error}</p>
-                        )}
-
-                        {fileItem.status === 'success' && (
-                          <p className="text-xs text-green-600 dark:text-green-400">
-                            Upload completed successfully!
-                          </p>
+                        {item.status === 'failed' && item.error && (
+                          <p className="mt-1 text-xs text-red-500">Error: {item.error}</p>
                         )}
                       </div>
 
-                      <div className="flex-shrink-0">
-                        {fileItem.status !== 'uploading' && (
+                      <div className="flex-shrink-0 flex items-center space-x-2">
+                        {(item.status === 'queued' || item.status === 'uploading') && (
+                          <Button variant="outline" size="sm" onClick={() => cancel(item.id)}>
+                            Cancel
+                          </Button>
+                        )}
+                        {(item.status === 'failed' || item.status === 'cancelled') && (
+                          <Button variant="outline" size="sm" onClick={() => retry(item.id)}>
+                            Retry
+                          </Button>
+                        )}
+                        {(item.status === 'succeeded' ||
+                          item.status === 'failed' ||
+                          item.status === 'cancelled') && (
                           <Button
                             variant="ghost"
                             size="sm"
-                            onClick={() => removeFile(fileItem.id)}
+                            onClick={() => remove(item.id)}
                             className="h-8 w-8 p-0"
-                            aria-label={`Remove ${fileItem.file.name}`}
+                            aria-label={`Remove ${item.file.name}`}
                           >
                             <X className="h-4 w-4" />
-                          </Button>
-                        )}
-                        {(fileItem.status === 'pending' || fileItem.status === 'error') && (
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => handleFileUpload(fileItem)}
-                            className="ml-2"
-                          >
-                            {fileItem.status === 'error' ? 'Retry' : 'Upload'}
                           </Button>
                         )}
                       </div>

--- a/client/src/services/cloudinaryUpload.ts
+++ b/client/src/services/cloudinaryUpload.ts
@@ -1,0 +1,57 @@
+import axios from 'axios';
+
+export interface CloudinaryAsset {
+  secure_url: string;
+  bytes: number;
+}
+
+interface CloudinaryResponse {
+  secure_url?: unknown;
+  bytes?: unknown;
+}
+
+function isCloudinaryAsset(value: unknown): value is CloudinaryAsset {
+  if (typeof value !== 'object' || value === null) return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.secure_url === 'string' &&
+    typeof candidate.bytes === 'number' &&
+    Number.isFinite(candidate.bytes) &&
+    candidate.bytes >= 0
+  );
+}
+
+export function uploadToCloudinary(
+  file: File,
+  signal: AbortSignal,
+  onProgress: (percent: number) => void
+): Promise<CloudinaryAsset> {
+  const url = import.meta.env.VITE_CLOUDINARY_URL as string;
+  const formData = new FormData();
+  formData.append('file', file);
+  formData.append('upload_preset', 'unsigned_upload');
+
+  const onUploadProgress = (event: { loaded: number; total?: number }) => {
+    if (event.total === undefined || event.total <= 0) return;
+    const percent = Math.round((event.loaded / event.total) * 100);
+    onProgress(Math.min(100, Math.max(0, percent)));
+  };
+
+  return axios
+    .post<CloudinaryResponse>(url, formData, { signal, onUploadProgress })
+    .then((response) => {
+      if (!isCloudinaryAsset(response.data)) {
+        throw new Error('Unexpected upload response');
+      }
+      return response.data;
+    })
+    .catch((error: unknown) => {
+      if (axios.isCancel(error)) {
+        throw new DOMException('Upload aborted', 'AbortError');
+      }
+      if (axios.isAxiosError(error) && error.response) {
+        throw new Error(`Upload failed (${error.response.status})`);
+      }
+      throw new Error('Network error during upload');
+    });
+}


### PR DESCRIPTION
## Summary
- process large upload batches with a maximum of three concurrent files
- validate type, 100 MiB size, 1,000-file cap, empty files, and duplicate queue entries before network work
- add real Axios upload progress, pause/resume, truthful upload cancellation, per-item retry, and batch summary
- cache successful Cloudinary assets so backend-save retry never uploads the file twice

## Architecture
- client queue is required because files upload directly from browser to Cloudinary
- existing Axios browser adapter provides progress and AbortSignal; no raw XHR/new dependency
- queue state, orchestration, and transport remain separated
- BullMQ/Redis is intentionally deferred to durable backend post-upload processing, not browser upload concurrency

## Verification
- queue tests: 11 passed, including 1,000 files with max concurrency 3
- client tests: 59 passed
- client build: passed
- client E2E: 7 passed
- Biome: passed

## Limitations
- raw File objects are not persisted across page refresh
- an already-started backend save is not presented as cancellable
- backend provider throttling and batch notifications remain in #365
- database idempotency/dedup remains in #366 after operator approval

## Database/backend impact
- client-only; no schema, migration, index, endpoint, or dependency changes

Closes #364