### PR TITLE
feat: bound backend upload work

### DIFF
--- a/backend/errors/too-many-requests-error.ts
+++ b/backend/errors/too-many-requests-error.ts
@@ -1,0 +1,15 @@
+import { CustomError } from './custom-error';
+
+export class TooManyRequestsError extends CustomError {
+  statusCode = 429;
+
+  constructor(message = 'Too many requests, please try again later') {
+    super(message);
+
+    Object.setPrototypeOf(this, TooManyRequestsError.prototype);
+  }
+
+  serializeErrors() {
+    return [{ message: this.message }];
+  }
+}

--- a/backend/routes/api/__test__/books.test.ts
+++ b/backend/routes/api/__test__/books.test.ts
@@ -171,6 +171,30 @@ it('keeps uploads successful when metadata enrichment fails', async () => {
   });
 });
 
+it('allows a normal client to upload up to three books concurrently without rate limiting', async () => {
+  const { accessToken, sender } = await global.signin();
+
+  const uploads = [1, 2, 3].map((index) =>
+    request(app)
+      .post('/api/books/addNewBook')
+      .set('Cookie', `accessToken=${accessToken}`)
+      .send({
+        ...VALID_BOOK_DATA,
+        name: `concurrent-upload-${index}`,
+        uploader: sender,
+      })
+      .expect(201)
+  );
+
+  const responses = await Promise.all(uploads);
+
+  expect(responses.map((response) => response.body.name).sort()).toEqual([
+    'concurrent-upload-1',
+    'concurrent-upload-2',
+    'concurrent-upload-3',
+  ]);
+});
+
 it('returns existing books that have no metadata', async () => {
   const { sender } = await global.signin();
   const legacyBook = await Books.create({

--- a/backend/services/book/__test__/uploadWorkLimiters.test.ts
+++ b/backend/services/book/__test__/uploadWorkLimiters.test.ts
@@ -1,0 +1,187 @@
+import { TooManyRequestsError } from '../../../errors/too-many-requests-error';
+import type { UploadWorkLimiterOptions, UploadWorkLimiters } from '../uploadWorkLimiters';
+import { createUploadWorkLimiters } from '../uploadWorkLimiters';
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+}
+
+const deferred = <T>(): Deferred<T> => {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+const waitUntil = async (predicate: () => boolean, timeoutMs = 2000): Promise<void> => {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      throw new Error('Condition not met within timeout');
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+};
+
+const createdLimiters: UploadWorkLimiters[] = [];
+
+const makeLimiters = (options?: UploadWorkLimiterOptions): UploadWorkLimiters => {
+  const limiters = createUploadWorkLimiters(options);
+  createdLimiters.push(limiters);
+  return limiters;
+};
+
+afterEach(async () => {
+  await Promise.all(createdLimiters.splice(0).map((limiters) => limiters.dispose()));
+});
+
+it('bounds the google provider to at most two concurrent calls', async () => {
+  const limiters = makeLimiters({
+    googleMaxConcurrent: 2,
+    googleMinTime: 0,
+    googleHighWater: 10,
+  });
+
+  let running = 0;
+  let maxRunning = 0;
+  const gates = Array.from({ length: 6 }, () => deferred<void>());
+
+  const jobs = gates.map((gate) =>
+    limiters.scheduleGoogle(async () => {
+      running += 1;
+      maxRunning = Math.max(maxRunning, running);
+      await gate.promise;
+      running -= 1;
+    })
+  );
+
+  await waitUntil(() => running === 2);
+
+  expect(maxRunning).toBe(2);
+  expect(running).toBe(2);
+
+  gates.forEach((gate) => {
+    gate.resolve();
+  });
+  await Promise.all(jobs);
+  expect(running).toBe(0);
+});
+
+it('bounds a single user to at most three concurrent uploads', async () => {
+  const limiters = makeLimiters({
+    userMinTime: 0,
+    userHighWater: 10,
+  });
+
+  let running = 0;
+  let maxRunning = 0;
+  const gates = Array.from({ length: 6 }, () => deferred<void>());
+
+  const jobs = gates.map((gate) =>
+    limiters.scheduleUser('user-a', async () => {
+      running += 1;
+      maxRunning = Math.max(maxRunning, running);
+      await gate.promise;
+      running -= 1;
+    })
+  );
+
+  await waitUntil(() => running === 3);
+
+  expect(maxRunning).toBe(3);
+  expect(running).toBe(3);
+
+  gates.forEach((gate) => {
+    gate.resolve();
+  });
+  await Promise.all(jobs);
+  expect(running).toBe(0);
+});
+
+it('allows two users to run up to six uploads while each key stays bounded at three', async () => {
+  const limiters = makeLimiters({
+    userMinTime: 0,
+    userHighWater: 10,
+  });
+
+  let running = 0;
+  let maxRunning = 0;
+  const perKeyRunning: Record<string, number> = {};
+  const perKeyMax: Record<string, number> = {};
+  const gates = Array.from({ length: 6 }, () => deferred<void>());
+
+  const jobs = gates.map((gate, index) => {
+    const key = index % 2 === 0 ? 'user-a' : 'user-b';
+    return limiters.scheduleUser(key, async () => {
+      running += 1;
+      maxRunning = Math.max(maxRunning, running);
+      perKeyRunning[key] = (perKeyRunning[key] ?? 0) + 1;
+      perKeyMax[key] = Math.max(perKeyMax[key] ?? 0, perKeyRunning[key]);
+      await gate.promise;
+      perKeyRunning[key] -= 1;
+      running -= 1;
+    });
+  });
+
+  await waitUntil(() => running === 6);
+
+  expect(maxRunning).toBe(6);
+  expect(perKeyMax['user-a']).toBe(3);
+  expect(perKeyMax['user-b']).toBe(3);
+
+  gates.forEach((gate) => {
+    gate.resolve();
+  });
+  await Promise.all(jobs);
+  expect(running).toBe(0);
+});
+
+it('rejects overflowed uploads with a 429 TooManyRequestsError', async () => {
+  const limiters = makeLimiters({
+    userMaxConcurrent: 1,
+    userMinTime: 0,
+    userHighWater: 0,
+  });
+
+  let running = 0;
+  const gate = deferred<void>();
+
+  const firstJob = limiters.scheduleUser('overflow-user', async () => {
+    running += 1;
+    await gate.promise;
+    return 'first';
+  });
+
+  await waitUntil(() => running === 1);
+
+  const overflowed = limiters.scheduleUser('overflow-user', async () => 'second');
+  const error = await overflowed.catch((caught: unknown) => caught);
+
+  expect(error).toBeInstanceOf(TooManyRequestsError);
+  expect((error as TooManyRequestsError).statusCode).toBe(429);
+  expect((error as TooManyRequestsError).serializeErrors()).toEqual([
+    { message: 'Too many requests, please try again later' },
+  ]);
+
+  gate.resolve();
+  await expect(firstJob).resolves.toBe('first');
+});
+
+it('passes task errors through unchanged', async () => {
+  const limiters = makeLimiters({
+    userMinTime: 0,
+  });
+
+  const taskError = new Error('task exploded');
+
+  await expect(
+    limiters.scheduleUser('task-error-user', async () => {
+      throw taskError;
+    })
+  ).rejects.toBe(taskError);
+});

--- a/backend/services/book/addNewBook.service.ts
+++ b/backend/services/book/addNewBook.service.ts
@@ -12,6 +12,7 @@ import {
 } from '../../web-push';
 import type { BookMetadata } from './googleBooksMetadata.service';
 import { fetchGoogleBooksMetadata } from './googleBooksMetadata.service';
+import { scheduleUserUpload } from './uploadWorkLimiters';
 
 const getTrimmedString = (value: unknown): string | undefined => {
   if (typeof value !== 'string') {
@@ -26,7 +27,7 @@ interface AuthenticatedUser {
   _id?: Types.ObjectId | string;
 }
 
-const addNewBook = async (req: Request) => {
+const addNewBookCore = async (req: Request) => {
   const user = req.user as AuthenticatedUser | undefined;
   const uploaderId = user?._id;
 
@@ -113,6 +114,17 @@ const addNewBook = async (req: Request) => {
   }
 
   return books;
+};
+
+const addNewBook = async (req: Request) => {
+  const user = req.user as AuthenticatedUser | undefined;
+  const uploaderId = user?._id;
+
+  if (!uploaderId) {
+    throw new NotAuthorizedError();
+  }
+
+  return scheduleUserUpload(uploaderId.toString(), () => addNewBookCore(req));
 };
 
 export { addNewBook };

--- a/backend/services/book/googleBooksMetadata.service.ts
+++ b/backend/services/book/googleBooksMetadata.service.ts
@@ -7,6 +7,7 @@ import type {
   Item,
   VolumeInfo,
 } from '../../routes/api/books.types';
+import { scheduleGoogleBooksMetadata } from './uploadWorkLimiters';
 
 const GOOGLE_BOOKS_API_URL = 'https://www.googleapis.com/books/v1/volumes';
 const GOOGLE_BOOKS_TIMEOUT_MS = 5000;
@@ -146,10 +147,12 @@ const fetchGoogleBooksMetadata = async (
       params.key = process.env.GOOGLE_BOOKS_API_KEY;
     }
 
-    const response = await axios.get<GoogleBooksResponse>(GOOGLE_BOOKS_API_URL, {
-      params,
-      timeout: GOOGLE_BOOKS_TIMEOUT_MS,
-    });
+    const response = await scheduleGoogleBooksMetadata(() =>
+      axios.get<GoogleBooksResponse>(GOOGLE_BOOKS_API_URL, {
+        params,
+        timeout: GOOGLE_BOOKS_TIMEOUT_MS,
+      })
+    );
 
     return getUsableMetadata(response.data?.items);
   } catch (error) {

--- a/backend/services/book/uploadWorkLimiters.ts
+++ b/backend/services/book/uploadWorkLimiters.ts
@@ -1,0 +1,69 @@
+import Bottleneck from 'bottleneck';
+import { TooManyRequestsError } from '../../errors/too-many-requests-error';
+
+export interface UploadWorkLimiterOptions {
+  googleMaxConcurrent?: number;
+  googleMinTime?: number;
+  googleHighWater?: number;
+  userMaxConcurrent?: number;
+  userMinTime?: number;
+  userHighWater?: number;
+  userIdleTimeout?: number;
+}
+
+export interface UploadWorkLimiters {
+  scheduleGoogle<T>(task: () => Promise<T>): Promise<T>;
+  scheduleUser<T>(userId: string, task: () => Promise<T>): Promise<T>;
+  dispose(): Promise<void>;
+}
+
+const isDroppedJobError = (error: unknown): boolean => error instanceof Bottleneck.BottleneckError;
+
+export const createUploadWorkLimiters = (
+  options: UploadWorkLimiterOptions = {}
+): UploadWorkLimiters => {
+  const googleLimiter = new Bottleneck({
+    maxConcurrent: options.googleMaxConcurrent ?? 2,
+    minTime: options.googleMinTime ?? 200,
+    highWater: options.googleHighWater ?? 50,
+    strategy: Bottleneck.strategy.OVERFLOW,
+  });
+
+  const userGroup = new Bottleneck.Group({
+    maxConcurrent: options.userMaxConcurrent ?? 3,
+    minTime: options.userMinTime ?? 50,
+    highWater: options.userHighWater ?? 20,
+    strategy: Bottleneck.strategy.OVERFLOW,
+    timeout: options.userIdleTimeout ?? 5 * 60 * 1000,
+  });
+
+  const dispose = async (): Promise<void> => {
+    await googleLimiter.stop({ dropWaitingJobs: true });
+    for (const key of userGroup.keys()) {
+      await userGroup.deleteKey(key);
+    }
+  };
+
+  return {
+    scheduleGoogle: <T>(task: () => Promise<T>): Promise<T> => googleLimiter.schedule(task),
+    scheduleUser: <T>(userId: string, task: () => Promise<T>): Promise<T> =>
+      userGroup
+        .key(userId)
+        .schedule(task)
+        .catch((error: unknown) => {
+          if (isDroppedJobError(error)) {
+            throw new TooManyRequestsError();
+          }
+          throw error;
+        }),
+    dispose,
+  };
+};
+
+const productionLimiters = createUploadWorkLimiters();
+
+export const scheduleGoogleBooksMetadata = <T>(task: () => Promise<T>): Promise<T> =>
+  productionLimiters.scheduleGoogle(task);
+
+export const scheduleUserUpload = <T>(userId: string, task: () => Promise<T>): Promise<T> =>
+  productionLimiters.scheduleUser(userId, task);


### PR DESCRIPTION
## Summary
- limit Google Books metadata requests globally with existing Bottleneck
- limit complete add-book operations to three concurrent jobs per authenticated user
- bound per-user waiting work and return a truthful 429 on overflow
- keep optional metadata/provider failure non-blocking for book persistence

## Limits
- Google Books: max 2 concurrent, 200 ms minimum spacing, queue high-water 50
- Per user: max 3 concurrent, 50 ms spacing, queue high-water 20
- Idle user limiter keys expire after five minutes
- Process-local by design; no Redis or database state

## Verification
- limiter tests: 5 passed
- backend tests: 46 passed
- backend build: passed
- Biome: passed

## Database/dependency impact
- no schema, migration, index, Redis, BullMQ, or new dependency
- separate users have independent per-user limits while sharing the provider limiter

Closes #373
