### PR TITLE
feat: add admin-only duplicate book audit

### DIFF
--- a/backend/controllers/duplicateAudit.controller.ts
+++ b/backend/controllers/duplicateAudit.controller.ts
@@ -1,0 +1,58 @@
+// duplicateAudit.controller.ts
+import type { NextFunction, Request, Response } from 'express';
+import type { DuplicateAuditType } from '../services/duplicateAudit/duplicateAudit.service';
+import {
+  DUPLICATE_AUDIT_TYPES,
+  runDuplicateAuditService,
+} from '../services/duplicateAudit/duplicateAudit.service';
+
+const MAX_LIMIT = 50;
+const DEFAULT_LIMIT = 20;
+
+const isDuplicateAuditType = (value: string): value is DuplicateAuditType =>
+  (DUPLICATE_AUDIT_TYPES as string[]).includes(value);
+
+const queryString = (value: unknown): string | undefined =>
+  typeof value === 'string' ? value : undefined;
+
+const parseBoundedInt = (value: unknown, min: number, max: number): number | null => {
+  const raw = queryString(value);
+  if (raw === undefined) return null;
+  if (!/^\d+$/.test(raw)) return null;
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed < min || parsed > max) return null;
+  return parsed;
+};
+
+export const getDuplicateAuditController = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    const typeValue = queryString(req.query.type) ?? 'url';
+    if (!isDuplicateAuditType(typeValue)) {
+      return res.status(400).json({ errors: [{ message: 'Invalid type', field: 'type' }] });
+    }
+
+    const page = parseBoundedInt(req.query.page, 1, Number.MAX_SAFE_INTEGER);
+    if (page === null && req.query.page !== undefined) {
+      return res.status(400).json({ errors: [{ message: 'Invalid page', field: 'page' }] });
+    }
+
+    const limit = parseBoundedInt(req.query.limit, 1, MAX_LIMIT);
+    if (limit === null && req.query.limit !== undefined) {
+      return res.status(400).json({ errors: [{ message: 'Invalid limit', field: 'limit' }] });
+    }
+
+    const result = await runDuplicateAuditService({
+      type: typeValue,
+      page: page ?? 1,
+      limit: limit ?? DEFAULT_LIMIT,
+    });
+
+    res.status(200).json(result);
+  } catch (err) {
+    next(err);
+  }
+};

--- a/backend/routes/api/__test__/duplicateAudit.test.ts
+++ b/backend/routes/api/__test__/duplicateAudit.test.ts
@@ -1,0 +1,346 @@
+import request from 'supertest';
+import { app } from '../../../app';
+import { Books } from '../../../models/Books';
+
+const getCookie = async (isAdmin = true) => {
+  const { accessToken } = await global.signin(isAdmin);
+  return `accessToken=${accessToken}`;
+};
+
+describe('GET /api/duplicate-audit', () => {
+  it('returns 401 when unauthenticated', async () => {
+    await request(app).get('/api/duplicate-audit').expect(401);
+  });
+
+  it('returns 403 for non-admin users', async () => {
+    const cookie = await getCookie(false);
+    await request(app).get('/api/duplicate-audit').set('Cookie', cookie).expect(403);
+  });
+
+  it('groups books by normalized URL', async () => {
+    const cookie = await getCookie();
+    await Books.insertMany([
+      { name: 'Alpha', url: 'HTTPS://Example.COM/Foo/Book.pdf?token=secret', size: 100 },
+      { name: 'Alpha', url: 'https://example.com/foo/book.pdf#section', size: 100 },
+      { name: 'Single', url: 'https://unique.example.com/only.pdf', size: 100 },
+    ]);
+
+    const res = await request(app)
+      .get('/api/duplicate-audit?type=url')
+      .set('Cookie', cookie)
+      .expect(200);
+
+    expect(res.body.type).toBe('url');
+    expect(res.body.summary.url).toBe(1);
+    expect(res.body.summary.isbn).toBe(0);
+    expect(res.body.totalGroups).toBe(1);
+    expect(res.body.scannedBooks).toBe(3);
+    expect(res.body.totalBooks).toBe(3);
+    expect(res.body.isTruncated).toBe(false);
+    expect(res.body.page).toBe(1);
+    expect(res.body.groups).toHaveLength(1);
+    expect(res.body.groups[0].count).toBe(2);
+    expect(res.body.groups[0].confidence).toBe('exact');
+    expect(res.body.groups[0].key).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('never returns raw URLs in the response', async () => {
+    const cookie = await getCookie();
+    const rawUrls = [
+      'HTTPS://Example.COM/Foo/Book.pdf?token=secret',
+      'https://example.com/foo/book.pdf#section',
+      'https://unique.example.com/only.pdf',
+    ];
+    await Books.insertMany([
+      { name: 'Alpha', url: rawUrls[0], size: 100 },
+      { name: 'Alpha', url: rawUrls[1], size: 100 },
+      { name: 'Single', url: rawUrls[2], size: 100 },
+    ]);
+
+    const res = await request(app)
+      .get('/api/duplicate-audit?type=url')
+      .set('Cookie', cookie)
+      .expect(200);
+
+    const body = JSON.stringify(res.body);
+    for (const raw of rawUrls) {
+      expect(body).not.toContain(raw);
+    }
+    expect(body).not.toContain('token=secret');
+
+    expect(Object.keys(res.body.groups[0].books[0]).sort()).toEqual([
+      'author',
+      'bookId',
+      'isbn',
+      'language',
+      'name',
+      'size',
+    ]);
+    for (const book of res.body.groups[0].books) {
+      expect(book).not.toHaveProperty('url');
+      expect(book).not.toHaveProperty('uploader');
+    }
+  });
+
+  it('groups books by normalized ISBN', async () => {
+    const cookie = await getCookie();
+    await Books.insertMany([
+      { name: 'Isbn One', url: 'https://a.example.com/1.pdf', size: 10, isbn: '978-0000000000' },
+      { name: 'Isbn Two', url: 'https://b.example.com/2.pdf', size: 20, isbn: '9780000000000' },
+      { name: 'Isbn Bad', url: 'https://c.example.com/3.pdf', size: 30, isbn: '12345' },
+    ]);
+
+    const res = await request(app)
+      .get('/api/duplicate-audit?type=isbn')
+      .set('Cookie', cookie)
+      .expect(200);
+
+    expect(res.body.summary.isbn).toBe(1);
+    expect(res.body.groups).toHaveLength(1);
+    expect(res.body.groups[0].count).toBe(2);
+    expect(res.body.groups[0].confidence).toBe('exact');
+    expect(res.body.groups[0].key).toBe('9780000000000');
+  });
+
+  it('groups books by normalized name and exact size', async () => {
+    const cookie = await getCookie();
+    await Books.insertMany([
+      { name: '  KÜÇÜK   PRENS ', url: 'https://a.example.com/1.pdf', size: 100 },
+      { name: 'kucuk prens', url: 'https://b.example.com/2.pdf', size: 100 },
+      { name: 'kucuk prens', url: 'https://c.example.com/3.pdf', size: 200 },
+    ]);
+
+    const res = await request(app)
+      .get('/api/duplicate-audit?type=name-size')
+      .set('Cookie', cookie)
+      .expect(200);
+
+    expect(res.body.summary['name-size']).toBe(1);
+    expect(res.body.groups).toHaveLength(1);
+    expect(res.body.groups[0].count).toBe(2);
+    expect(res.body.groups[0].confidence).toBe('exact');
+    expect(res.body.groups[0].key).toBe('kucuk prens :: 100');
+    // Display keys must never leak NUL control characters into clients/CSV.
+    expect(JSON.stringify(res.body)).not.toContain('\\u0000');
+  });
+
+  it('groups TITANIC and Titanic (dotted I vs plain case) under the same key', async () => {
+    const cookie = await getCookie();
+    await Books.insertMany([
+      { name: 'TITANIC', url: 'https://a.example.com/titanic.pdf', size: 100 },
+      { name: 'Titanic', url: 'https://b.example.com/titanic.pdf', size: 100 },
+    ]);
+
+    const res = await request(app)
+      .get('/api/duplicate-audit?type=name-size')
+      .set('Cookie', cookie)
+      .expect(200);
+
+    expect(res.body.summary['name-size']).toBe(1);
+    expect(res.body.groups).toHaveLength(1);
+    expect(res.body.groups[0].count).toBe(2);
+    expect(res.body.groups[0].key).toBe('titanic :: 100');
+  });
+
+  it('groups İstanbul and Istanbul (dotted vs dotless i) under the same key', async () => {
+    const cookie = await getCookie();
+    await Books.insertMany([
+      { name: 'İstanbul', url: 'https://a.example.com/istanbul.pdf', size: 100 },
+      { name: 'Istanbul', url: 'https://b.example.com/istanbul.pdf', size: 100 },
+    ]);
+
+    const res = await request(app)
+      .get('/api/duplicate-audit?type=name-size')
+      .set('Cookie', cookie)
+      .expect(200);
+
+    expect(res.body.summary['name-size']).toBe(1);
+    expect(res.body.groups).toHaveLength(1);
+    expect(res.body.groups[0].count).toBe(2);
+    expect(res.body.groups[0].key).toBe('istanbul :: 100');
+  });
+
+  it('reports isTruncated=false and totalBooks for a small collection', async () => {
+    const cookie = await getCookie();
+    await Books.insertMany([
+      { name: 'Alpha', url: 'https://a.example.com/1.pdf', size: 100 },
+      { name: 'Alpha', url: 'https://b.example.com/1.pdf', size: 100 },
+    ]);
+
+    const res = await request(app)
+      .get('/api/duplicate-audit?type=url')
+      .set('Cookie', cookie)
+      .expect(200);
+
+    expect(res.body.totalBooks).toBe(2);
+    expect(res.body.scannedBooks).toBe(2);
+    expect(res.body.isTruncated).toBe(false);
+  });
+
+  it('flags isTruncated when the collection exceeds the 10k scan bound', async () => {
+    const cookie = await getCookie();
+    const fixtures = Array.from({ length: 10_001 }, (_, i) => ({
+      name: `Book ${i}`,
+      url: `https://t${i}.example.com/only.pdf`,
+      size: 1,
+    }));
+    await Books.insertMany(fixtures);
+
+    const res = await request(app)
+      .get('/api/duplicate-audit?type=url')
+      .set('Cookie', cookie)
+      .expect(200);
+
+    expect(res.body.totalBooks).toBe(10_001);
+    expect(res.body.scannedBooks).toBe(10_000);
+    expect(res.body.isTruncated).toBe(true);
+  });
+
+  it('groups soft candidates by title, author and language including Turkish, legacy and same-title different-size', async () => {
+    const cookie = await getCookie();
+    await Books.insertMany([
+      {
+        name: 'Küçük Prens',
+        author: 'Antoine de Saint-Exupéry',
+        url: 'https://a.example.com/1.pdf',
+        size: 100,
+        language: 'turkish',
+      },
+      {
+        name: 'KUCUK PRENS',
+        author: 'Antoine de Saint-Exupery',
+        url: 'https://b.example.com/2.pdf',
+        size: 500,
+        language: 'turkish',
+      },
+      {
+        name: 'Antoine de Saint-Exupéry - Küçük Prens',
+        author: null,
+        url: 'https://c.example.com/3.pdf',
+        size: 300,
+        language: 'turkish',
+      },
+      {
+        name: 'Küçük Prens',
+        author: 'Başka Yazar',
+        url: 'https://d.example.com/4.pdf',
+        size: 100,
+        language: 'turkish',
+      },
+    ]);
+
+    const res = await request(app)
+      .get('/api/duplicate-audit?type=title-author-language')
+      .set('Cookie', cookie)
+      .expect(200);
+
+    expect(res.body.summary['title-author-language']).toBe(1);
+    expect(res.body.groups).toHaveLength(1);
+    expect(res.body.groups[0].count).toBe(3);
+    expect(res.body.groups[0].confidence).toBe('soft');
+    expect(res.body.groups[0].books.map((b: { name: string }) => b.name).sort()).toEqual([
+      'Antoine de Saint-Exupéry - Küçük Prens',
+      'KUCUK PRENS',
+      'Küçük Prens',
+    ]);
+  });
+
+  it('paginates selected groups and reports totals', async () => {
+    const cookie = await getCookie();
+    const fixtures = Array.from({ length: 6 }, (_, i) => [
+      { name: `Book ${i}`, url: `https://a${i}.example.com/1.pdf`, size: i + 1 },
+      { name: `Book ${i}`, url: `https://b${i}.example.com/2.pdf`, size: i + 1 },
+    ]).flat();
+    await Books.insertMany(fixtures);
+
+    const page1 = await request(app)
+      .get('/api/duplicate-audit?type=name-size&page=1&limit=2')
+      .set('Cookie', cookie)
+      .expect(200);
+
+    expect(page1.body.totalGroups).toBe(6);
+    expect(page1.body.page).toBe(1);
+    expect(page1.body.limit).toBe(2);
+    expect(page1.body.groups).toHaveLength(2);
+
+    const page3 = await request(app)
+      .get('/api/duplicate-audit?type=name-size&page=3&limit=2')
+      .set('Cookie', cookie)
+      .expect(200);
+
+    expect(page3.body.groups).toHaveLength(2);
+    const names = page3.body.groups.flatMap((g: { books: { name: string }[] }) =>
+      g.books.map((b) => b.name)
+    );
+    expect(names.sort()).toEqual(['Book 4', 'Book 4', 'Book 5', 'Book 5']);
+  });
+
+  it('returns 400 for invalid query parameters', async () => {
+    const cookie = await getCookie();
+    const invalidQueries = [
+      '?type=bogus',
+      '?type=',
+      '?page=0',
+      '?page=abc',
+      '?page=-1',
+      '?limit=0',
+      '?limit=51',
+      '?limit=abc',
+    ];
+
+    for (const query of invalidQueries) {
+      const res = await request(app)
+        .get(`/api/duplicate-audit${query}`)
+        .set('Cookie', cookie)
+        .expect(400);
+      expect(res.body.errors).toBeDefined();
+    }
+  });
+
+  it('leaves the Books collection byte-for-byte unchanged', async () => {
+    const cookie = await getCookie();
+    await Books.insertMany([
+      {
+        name: 'Küçük Prens',
+        author: 'Antoine de Saint-Exupéry',
+        url: 'https://a.example.com/1.pdf',
+        size: 100,
+        isbn: '978-0000000000',
+        language: 'turkish',
+      },
+      {
+        name: 'KUCUK PRENS',
+        author: 'Antoine de Saint-Exupery',
+        url: 'https://b.example.com/2.pdf',
+        size: 500,
+        language: 'turkish',
+      },
+      { name: 'Single', url: 'https://unique.example.com/only.pdf', size: 100, isbn: '12345' },
+    ]);
+
+    const snapshot = async () => {
+      const docs = await Books.find({}, '_id name size url isbn author language').lean();
+      return {
+        count: await Books.countDocuments(),
+        json: JSON.stringify(docs),
+      };
+    };
+
+    const before = await snapshot();
+
+    await request(app).get('/api/duplicate-audit?type=url').set('Cookie', cookie).expect(200);
+    await request(app)
+      .get('/api/duplicate-audit?type=isbn&limit=1')
+      .set('Cookie', cookie)
+      .expect(200);
+    await request(app)
+      .get('/api/duplicate-audit?type=title-author-language')
+      .set('Cookie', cookie)
+      .expect(200);
+
+    const after = await snapshot();
+
+    expect(after.count).toBe(before.count);
+    expect(after.json).toBe(before.json);
+  });
+});

--- a/backend/routes/api/duplicateAudit.ts
+++ b/backend/routes/api/duplicateAudit.ts
@@ -1,0 +1,11 @@
+import express from 'express';
+import { getDuplicateAuditController } from '../../controllers/duplicateAudit.controller';
+import { isAdmin } from '../../middleware/auth';
+
+const router = express.Router();
+
+// GET /api/duplicate-audit?type=url&page=1&limit=20
+// Protected: Admin only, read-only duplicate audit over Books.
+router.get('/', isAdmin, getDuplicateAuditController);
+
+export { router as duplicateAuditRouter };

--- a/backend/routes/index.ts
+++ b/backend/routes/index.ts
@@ -1,10 +1,11 @@
 import express from 'express';
-import { booksRouter } from './api/books';
-import { userRouter } from './api/user';
-import { messagesRouter } from './api/messages';
-import { subscriptionRouter } from './api/subscription';
-import { ratingsRouter } from './api/ratings';
 import { analyticsRouter } from './api/analytics';
+import { booksRouter } from './api/books';
+import { duplicateAuditRouter } from './api/duplicateAudit';
+import { messagesRouter } from './api/messages';
+import { ratingsRouter } from './api/ratings';
+import { subscriptionRouter } from './api/subscription';
+import { userRouter } from './api/user';
 
 const router = express.Router();
 
@@ -14,5 +15,6 @@ router.use('/messages', messagesRouter);
 router.use('/subscription', subscriptionRouter);
 router.use('/ratings', ratingsRouter);
 router.use('/analytics', analyticsRouter);
+router.use('/duplicate-audit', duplicateAuditRouter);
 
 export default router;

--- a/backend/services/duplicateAudit/duplicateAudit.service.ts
+++ b/backend/services/duplicateAudit/duplicateAudit.service.ts
@@ -1,0 +1,257 @@
+// duplicateAudit.service.ts
+import { createHash } from 'node:crypto';
+import { logger } from '../../logger';
+import { Books } from '../../models/Books';
+
+export type DuplicateAuditType = 'url' | 'isbn' | 'name-size' | 'title-author-language';
+
+export type DuplicateAuditConfidence = 'exact' | 'soft';
+
+export interface DuplicateAuditBookItem {
+  bookId: string;
+  name: string;
+  size?: number;
+  author: string | null;
+  isbn: string | null;
+  language: string;
+}
+
+export interface DuplicateAuditGroup {
+  key: string;
+  type: DuplicateAuditType;
+  confidence: DuplicateAuditConfidence;
+  count: number;
+  books: DuplicateAuditBookItem[];
+}
+
+export type DuplicateAuditSummary = Record<DuplicateAuditType, number>;
+
+export interface DuplicateAuditResult {
+  type: DuplicateAuditType;
+  summary: DuplicateAuditSummary;
+  groups: DuplicateAuditGroup[];
+  totalGroups: number;
+  page: number;
+  limit: number;
+  scannedBooks: number;
+  totalBooks: number;
+  isTruncated: boolean;
+  durationMs: number;
+}
+
+export interface DuplicateAuditQuery {
+  type: DuplicateAuditType;
+  page: number;
+  limit: number;
+}
+
+const SCAN_LIMIT = 10_000;
+const FIELD_SEPARATOR = '\u0000';
+const READABLE_SEPARATOR = ' :: ';
+
+export const DUPLICATE_AUDIT_TYPES: DuplicateAuditType[] = [
+  'url',
+  'isbn',
+  'name-size',
+  'title-author-language',
+];
+
+interface ScannedBook {
+  _id: unknown;
+  name?: string;
+  size?: number;
+  url?: string;
+  isbn?: string | null;
+  author?: string | null;
+  language?: string;
+}
+
+const normalizeUrl = (value: string): string | null => {
+  try {
+    const parsed = new URL(value.trim());
+    const host = parsed.hostname.toLowerCase();
+    let path = parsed.pathname.toLowerCase();
+    if (path.length > 1 && path.endsWith('/')) {
+      path = path.slice(0, -1);
+    }
+    return `${host}${path}`;
+  } catch {
+    return null;
+  }
+};
+
+const normalizeIsbn = (value: string): string | null => {
+  const digits = value.toUpperCase().replace(/[^0-9X]/g, '');
+  return digits.length === 10 || digits.length === 13 ? digits : null;
+};
+
+// Turkish-safe normalization: NFKD, strip combining marks, collapse every
+// dotted/dotless i variant (I/İ/ı/i) to ASCII 'i', then lowercase and filter.
+// This keeps TITANIC/Titanic and Istanbul/İstanbul on the same key.
+const normalizeString = (value: string): string =>
+  value
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[İIı]/g, 'i')
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+const sha256UrlKey = (value: string): string => createHash('sha256').update(value).digest('hex');
+
+// Internal map keys may keep the NUL separator; the key sent to clients must be
+// free of control characters and human-readable (NUL breaks CSV exports).
+const toDisplayKey = (key: string, type: DuplicateAuditType): string => {
+  if (type === 'url' || type === 'isbn') return key;
+  return key.split(FIELD_SEPARATOR).join(READABLE_SEPARATOR);
+};
+
+const splitLegacyAuthor = (name: string): { title: string; author: string } => {
+  const separator = ' - ';
+  const index = name.indexOf(separator);
+  if (index === -1) {
+    return { title: name, author: '' };
+  }
+  return {
+    title: name.slice(index + separator.length),
+    author: name.slice(0, index),
+  };
+};
+
+const getTitleAndAuthor = (book: ScannedBook): { title: string; author: string } => {
+  const name = typeof book.name === 'string' ? book.name.trim() : '';
+  if (typeof book.author === 'string' && book.author.trim()) {
+    return { title: name, author: book.author };
+  }
+  return splitLegacyAuthor(name);
+};
+
+const toBookItem = (book: ScannedBook): DuplicateAuditBookItem => ({
+  bookId: String(book._id),
+  name: typeof book.name === 'string' ? book.name : '',
+  size: typeof book.size === 'number' ? book.size : undefined,
+  author: typeof book.author === 'string' ? book.author : null,
+  isbn: typeof book.isbn === 'string' ? book.isbn : null,
+  language: typeof book.language === 'string' ? book.language : 'turkish',
+});
+
+const computeKeys = (book: ScannedBook): Record<DuplicateAuditType, string | null> => {
+  const normalizedName = normalizeString(typeof book.name === 'string' ? book.name : '');
+  const normalizedIsbn = normalizeIsbn(typeof book.isbn === 'string' ? book.isbn : '');
+  const normalizedUrl = normalizeUrl(typeof book.url === 'string' ? book.url : '');
+  const size = typeof book.size === 'number' && Number.isFinite(book.size) ? book.size : null;
+  const { title, author } = getTitleAndAuthor(book);
+  const normalizedTitle = normalizeString(title);
+  const normalizedAuthor = normalizeString(author);
+  const language = typeof book.language === 'string' ? book.language.toLowerCase() : 'turkish';
+
+  return {
+    url: normalizedUrl,
+    isbn: normalizedIsbn,
+    'name-size':
+      normalizedName && size !== null ? `${normalizedName}${FIELD_SEPARATOR}${size}` : null,
+    'title-author-language': normalizedTitle
+      ? `${normalizedTitle}${FIELD_SEPARATOR}${normalizedAuthor}${FIELD_SEPARATOR}${language}`
+      : null,
+  };
+};
+
+const buildGroupMaps = (
+  books: ScannedBook[]
+): Record<DuplicateAuditType, Map<string, DuplicateAuditBookItem[]>> => {
+  const groupMaps: Record<DuplicateAuditType, Map<string, DuplicateAuditBookItem[]>> = {
+    url: new Map(),
+    isbn: new Map(),
+    'name-size': new Map(),
+    'title-author-language': new Map(),
+  };
+
+  for (const book of books) {
+    const keys = computeKeys(book);
+    const item = toBookItem(book);
+    for (const type of DUPLICATE_AUDIT_TYPES) {
+      const key = keys[type];
+      if (!key) continue;
+      const bucket = groupMaps[type].get(key);
+      if (bucket) {
+        bucket.push(item);
+      } else {
+        groupMaps[type].set(key, [item]);
+      }
+    }
+  }
+
+  return groupMaps;
+};
+
+const buildGroups = (
+  groupMaps: Record<DuplicateAuditType, Map<string, DuplicateAuditBookItem[]>>
+): Record<DuplicateAuditType, DuplicateAuditGroup[]> => {
+  const result = {} as Record<DuplicateAuditType, DuplicateAuditGroup[]>;
+  for (const type of DUPLICATE_AUDIT_TYPES) {
+    const groups: DuplicateAuditGroup[] = [];
+    for (const [key, books] of groupMaps[type]) {
+      if (books.length < 2) continue;
+      groups.push({
+        key: type === 'url' ? sha256UrlKey(key) : toDisplayKey(key, type),
+        type,
+        confidence: type === 'title-author-language' ? 'soft' : 'exact',
+        count: books.length,
+        books,
+      });
+    }
+    result[type] = groups.sort((a, b) => b.count - a.count || a.key.localeCompare(b.key));
+  }
+  return result;
+};
+
+export const runDuplicateAuditService = async (
+  query: DuplicateAuditQuery
+): Promise<DuplicateAuditResult> => {
+  const startedAt = Date.now();
+
+  const scanned = (await Books.find()
+    .select('_id name size url isbn author language')
+    .limit(SCAN_LIMIT)
+    .lean()) as unknown as ScannedBook[];
+  const scannedBooks = scanned.length;
+  // Count the full collection so callers know when the hard scan bound hid books.
+  const totalBooks = await Books.countDocuments();
+  const isTruncated = totalBooks > scannedBooks;
+
+  const allGroups = buildGroups(buildGroupMaps(scanned));
+
+  const summary: DuplicateAuditSummary = {
+    url: allGroups.url.length,
+    isbn: allGroups.isbn.length,
+    'name-size': allGroups['name-size'].length,
+    'title-author-language': allGroups['title-author-language'].length,
+  };
+
+  const selected = allGroups[query.type];
+  const startIndex = (query.page - 1) * query.limit;
+  const groups = selected.slice(startIndex, startIndex + query.limit);
+
+  const durationMs = Date.now() - startedAt;
+  logger.info('Duplicate audit completed', {
+    durationMs,
+    scannedBooks,
+    totalBooks,
+    isTruncated,
+    groupCounts: summary,
+  });
+
+  return {
+    type: query.type,
+    summary,
+    groups,
+    totalGroups: selected.length,
+    page: query.page,
+    limit: query.limit,
+    scannedBooks,
+    totalBooks,
+    isTruncated,
+    durationMs,
+  };
+};

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -88,6 +88,7 @@ export default function NavbarComponent() {
                 </NavLink>
               ))}
               {showAdminLink && <NavLink to="/admin/analytics">Analytics</NavLink>}
+              {showAdminLink && <NavLink to="/admin/duplicate-audit">Duplicate Audit</NavLink>}
             </div>
 
             {/* User Navigation & Mobile Menu Button */}
@@ -135,6 +136,11 @@ export default function NavbarComponent() {
               {showAdminLink && (
                 <NavLink to="/admin/analytics" mobile>
                   Analytics
+                </NavLink>
+              )}
+              {showAdminLink && (
+                <NavLink to="/admin/duplicate-audit" mobile>
+                  Duplicate Audit
                 </NavLink>
               )}
               <div className="flex items-center justify-between pt-2">

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -27,6 +27,7 @@ const BookEditPage = lazy(() =>
 );
 const ContactUs = lazy(() => import('./pages/ContactPage').then((m) => ({ default: m.ContactUs })));
 const AdminAnalytics = lazy(() => import('./pages/AdminAnalytics'));
+const AdminDuplicateAudit = lazy(() => import('./pages/AdminDuplicateAudit'));
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 
@@ -85,6 +86,14 @@ root.render(
               element={
                 <PrivateRoute>
                   <AdminAnalytics />
+                </PrivateRoute>
+              }
+            />
+            <Route
+              path="/admin/duplicate-audit"
+              element={
+                <PrivateRoute>
+                  <AdminDuplicateAudit />
                 </PrivateRoute>
               }
             />

--- a/client/src/pages/AdminDuplicateAudit.tsx
+++ b/client/src/pages/AdminDuplicateAudit.tsx
@@ -1,0 +1,325 @@
+import { AlertTriangle, ChevronLeft, ChevronRight, Download, Play, Search } from 'lucide-react';
+import { useState } from 'react';
+import { useSelector } from 'react-redux';
+import { Navigate } from 'react-router-dom';
+import Layout from '@/components/Layout';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { LoadingSpinner } from '@/components/ui/loading';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  type DuplicateAuditResult,
+  type DuplicateAuditType,
+  useLazyGetDuplicateAuditQuery,
+} from '@/redux/services/duplicateAudit.api';
+import type { RootState } from '@/redux/store';
+
+const TYPE_OPTIONS: DuplicateAuditType[] = ['url', 'isbn', 'name-size', 'title-author-language'];
+
+const TYPE_LABELS: Record<DuplicateAuditType, string> = {
+  url: 'URL',
+  isbn: 'ISBN',
+  'name-size': 'Name + Size',
+  'title-author-language': 'Title + Author + Language',
+};
+
+const PAGE_SIZE = 20;
+
+/**
+ * Escape a single CSV cell: double embedded quotes and wrap cells containing
+ * quotes, commas or line breaks. Prefix cells that would be interpreted as a
+ * spreadsheet formula with a single quote to prevent CSV injection.
+ */
+const csvEscape = (value: unknown): string => {
+  let text = value == null ? '' : String(value);
+  if (/^[=+\-@\t\r]/.test(text)) {
+    text = `'${text}`;
+  }
+  if (/[",\n\r]/.test(text)) {
+    text = `"${text.replace(/"/g, '""')}"`;
+  }
+  return text;
+};
+
+const toCsv = (report: DuplicateAuditResult): string => {
+  const header = [
+    'Group Key',
+    'Reason',
+    'Confidence',
+    'Count',
+    'Book ID',
+    'Name',
+    'Author',
+    'ISBN',
+    'Language',
+    'Size',
+  ].join(',');
+
+  const rows = report.groups.flatMap((group) =>
+    group.books.map((book) =>
+      [
+        group.key,
+        TYPE_LABELS[group.type],
+        group.confidence,
+        String(group.count),
+        book.bookId,
+        book.name,
+        book.author ?? '',
+        book.isbn ?? '',
+        book.language,
+        book.size ?? '',
+      ]
+        .map(csvEscape)
+        .join(',')
+    )
+  );
+
+  return [header, ...rows].join('\n');
+};
+
+const downloadBlob = (blob: Blob, filename: string) => {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+};
+
+const AdminDuplicateAudit = () => {
+  const [type, setType] = useState<DuplicateAuditType>('url');
+
+  const { user, isLoggedIn } = useSelector((state: RootState) => state.authSlice);
+  const isAdmin = isLoggedIn && user.user.isAdmin;
+
+  const [trigger, { data, isFetching, isError, error }] = useLazyGetDuplicateAuditQuery();
+
+  const totalPages = data ? Math.max(1, Math.ceil(data.totalGroups / data.limit)) : 1;
+  const errorMessage = (error as { data?: { errors?: { message?: string }[] } })?.data?.errors?.[0]
+    ?.message;
+
+  // Redirect non-admin users
+  if (!isAdmin) {
+    return <Navigate to="/" replace />;
+  }
+
+  const runAudit = (nextType = type, nextPage = 1) => {
+    setType(nextType);
+    void trigger({ type: nextType, page: nextPage, limit: PAGE_SIZE });
+  };
+
+  const handlePageChange = (nextPage: number) => {
+    void trigger({ type, page: nextPage, limit: PAGE_SIZE });
+  };
+
+  const downloadJson = () => {
+    if (!data) return;
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+    downloadBlob(blob, `duplicate-audit-${data.type}.json`);
+  };
+
+  const downloadCsv = () => {
+    if (!data) return;
+    const blob = new Blob([toCsv(data)], { type: 'text/csv;charset=utf-8' });
+    downloadBlob(blob, `duplicate-audit-${data.type}.csv`);
+  };
+
+  return (
+    <Layout>
+      <div className="container mx-auto px-4 py-8">
+        <div className="flex items-center gap-3 mb-6">
+          <Search className="h-8 w-8" />
+          <h1 className="text-3xl font-bold">Duplicate Audit</h1>
+        </div>
+
+        <Card className="p-6 mb-6">
+          <div className="flex flex-wrap items-end gap-4">
+            <div className="flex flex-col gap-2">
+              <label htmlFor="duplicate-audit-type" className="text-sm font-medium">
+                Audit Type
+              </label>
+              <Select value={type} onValueChange={(value) => setType(value as DuplicateAuditType)}>
+                <SelectTrigger id="duplicate-audit-type" className="w-[240px]">
+                  <SelectValue placeholder="Select audit type" />
+                </SelectTrigger>
+                <SelectContent>
+                  {TYPE_OPTIONS.map((option) => (
+                    <SelectItem key={option} value={option}>
+                      {TYPE_LABELS[option]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <Button onClick={() => runAudit(type)} disabled={isFetching}>
+              {isFetching ? <LoadingSpinner size={16} /> : <Play className="h-4 w-4" />}
+              {isFetching ? 'Running…' : 'Run Audit'}
+            </Button>
+          </div>
+        </Card>
+
+        {isError ? (
+          <Card className="p-6">
+            <div className="flex items-start gap-3">
+              <AlertTriangle className="mt-0.5 h-5 w-5 text-destructive" />
+              <div>
+                <p className="font-medium text-destructive">Audit failed</p>
+                <p className="text-sm text-muted-foreground">
+                  {errorMessage || 'Something went wrong. Please try again.'}
+                </p>
+              </div>
+            </div>
+          </Card>
+        ) : isFetching && !data ? (
+          <Card className="p-6">
+            <div className="flex items-center justify-center gap-3 py-12">
+              <LoadingSpinner />
+              <span className="text-muted-foreground">Scanning books…</span>
+            </div>
+          </Card>
+        ) : data ? (
+          <>
+            {data.isTruncated && (
+              <Alert variant="destructive" className="mb-6" data-testid="truncated-warning">
+                <AlertTriangle className="h-4 w-4" />
+                <AlertTitle>Scan limit reached</AlertTitle>
+                <AlertDescription>
+                  This audit scanned {data.scannedBooks.toLocaleString()} of{' '}
+                  {data.totalBooks.toLocaleString()} books. Results may be incomplete.
+                </AlertDescription>
+              </Alert>
+            )}
+
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 mb-6">
+              {TYPE_OPTIONS.map((option) => (
+                <Card key={option} className="p-4" data-testid={`summary-${option}`}>
+                  <p className="text-sm font-medium text-muted-foreground">{TYPE_LABELS[option]}</p>
+                  <p className="mt-1 text-2xl font-bold">{data.summary[option]}</p>
+                </Card>
+              ))}
+              <Card className="p-4" data-testid="summary-scanned">
+                <p className="text-sm font-medium text-muted-foreground">Scanned Books</p>
+                <p className="mt-1 text-2xl font-bold">{data.scannedBooks}</p>
+              </Card>
+              <Card className="p-4" data-testid="summary-total-groups">
+                <p className="text-sm font-medium text-muted-foreground">Total Groups</p>
+                <p className="mt-1 text-2xl font-bold">{data.totalGroups}</p>
+              </Card>
+            </div>
+
+            {data.groups.length === 0 ? (
+              <Card className="p-6">
+                <p className="text-center text-muted-foreground">
+                  No duplicate groups found for {TYPE_LABELS[data.type].toLowerCase()}.
+                </p>
+              </Card>
+            ) : (
+              <Card>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Group Key</TableHead>
+                      <TableHead>Reason</TableHead>
+                      <TableHead>Confidence</TableHead>
+                      <TableHead>Book ID</TableHead>
+                      <TableHead>Name</TableHead>
+                      <TableHead>Author</TableHead>
+                      <TableHead>ISBN</TableHead>
+                      <TableHead>Language</TableHead>
+                      <TableHead className="text-right">Size</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {data.groups.flatMap((group) =>
+                      group.books.map((book) => (
+                        <TableRow key={`${group.key}-${book.bookId}`}>
+                          <TableCell className="font-mono text-xs">{group.key}</TableCell>
+                          <TableCell>{TYPE_LABELS[group.type]}</TableCell>
+                          <TableCell>
+                            <Badge variant={group.confidence === 'exact' ? 'success' : 'warning'}>
+                              {group.confidence}
+                            </Badge>
+                          </TableCell>
+                          <TableCell className="font-mono text-xs">{book.bookId}</TableCell>
+                          <TableCell>{book.name}</TableCell>
+                          <TableCell>{book.author ?? '—'}</TableCell>
+                          <TableCell>{book.isbn ?? '—'}</TableCell>
+                          <TableCell>{book.language}</TableCell>
+                          <TableCell className="text-right">{book.size ?? '—'}</TableCell>
+                        </TableRow>
+                      ))
+                    )}
+                  </TableBody>
+                </Table>
+              </Card>
+            )}
+
+            <div className="flex flex-wrap items-center justify-between gap-4 mt-6">
+              <div className="flex flex-wrap gap-2">
+                <Button variant="outline" size="sm" onClick={downloadJson} disabled={isFetching}>
+                  <Download className="h-4 w-4" />
+                  Download JSON
+                </Button>
+                <Button variant="outline" size="sm" onClick={downloadCsv} disabled={isFetching}>
+                  <Download className="h-4 w-4" />
+                  Download CSV
+                </Button>
+              </div>
+
+              <div className="flex items-center gap-2">
+                <span className="text-sm text-muted-foreground">
+                  Page {data.page} of {totalPages} ({data.totalGroups} groups)
+                </span>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handlePageChange(data.page - 1)}
+                  disabled={isFetching || data.page <= 1}
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                  Previous
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handlePageChange(data.page + 1)}
+                  disabled={isFetching || data.page >= totalPages}
+                >
+                  Next
+                  <ChevronRight className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+          </>
+        ) : (
+          <Card className="p-6">
+            <p className="text-center text-muted-foreground">
+              Run an audit to detect duplicate books. No request is sent until you click Run.
+            </p>
+          </Card>
+        )}
+      </div>
+    </Layout>
+  );
+};
+
+export default AdminDuplicateAudit;

--- a/client/src/pages/__tests__/AdminDuplicateAudit.test.tsx
+++ b/client/src/pages/__tests__/AdminDuplicateAudit.test.tsx
@@ -1,0 +1,301 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { type ReactNode, useState } from 'react';
+import { Provider } from 'react-redux';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import AdminDuplicateAudit from '@/pages/AdminDuplicateAudit';
+import authReducer, { loadUser } from '@/redux/authSlice';
+import { commonApi } from '@/redux/common.api';
+import type { DuplicateAuditResult } from '@/redux/services/duplicateAudit.api';
+
+// Partial-mock the audit API only: the hook is stubbed while the real
+// commonApi reducer and middleware stay in the test store.
+const apiMocks = vi.hoisted(() => {
+  const state: {
+    data: DuplicateAuditResult | null;
+    isFetching: boolean;
+    isError: boolean;
+    error: unknown;
+  } = { data: null, isFetching: false, isError: false, error: undefined };
+
+  return {
+    trigger: vi.fn(),
+    state,
+    reset() {
+      state.data = null;
+      state.isFetching = false;
+      state.isError = false;
+      state.error = undefined;
+      apiMocks.trigger.mockClear();
+    },
+  };
+});
+
+vi.mock('@/redux/services/duplicateAudit.api', () => ({
+  // Stateful stub: trigger records its args and snapshots apiMocks.state so a
+  // click alone re-renders the page with the latest result (no manual
+  // same-element rerender needed).
+  useLazyGetDuplicateAuditQuery: () => {
+    const [result, setResult] = useState({ ...apiMocks.state });
+    const trigger = (args: unknown) => {
+      apiMocks.trigger(args);
+      setResult({ ...apiMocks.state });
+    };
+    return [trigger, result];
+  },
+}));
+
+// Mock the Layout shell so the test stays focused on the audit page itself.
+vi.mock('@/components/Layout', () => ({
+  default: ({ children }: { children: ReactNode }) => <div data-testid="layout">{children}</div>,
+}));
+
+// jsdom's Blob does not implement .text(); read through FileReader instead.
+const readBlobAsText = (blob: Blob) =>
+  new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result));
+    reader.onerror = () => reject(reader.error ?? new Error('Failed to read Blob'));
+    reader.readAsText(blob);
+  });
+
+/**
+ * Pull the first Blob passed to URL.createObjectURL out of a vi.fn() mock.
+ * Throws an explicit error instead of silently casting `undefined` when the
+ * mock was never called or was called with a non-Blob first argument.
+ */
+const firstObjectUrlBlob = (createObjectURL: {
+  mock: { calls: ReadonlyArray<readonly unknown[]> };
+}): Blob => {
+  const firstCall = createObjectURL.mock.calls[0];
+  const firstArg = firstCall?.[0];
+  if (!(firstArg instanceof Blob)) {
+    throw new Error('Expected URL.createObjectURL to be called with a Blob as its first argument');
+  }
+  return firstArg;
+};
+
+const report: DuplicateAuditResult = {
+  type: 'url',
+  summary: { url: 1, isbn: 0, 'name-size': 0, 'title-author-language': 0 },
+  groups: [
+    {
+      key: 'a1b2c3d4e5f60718',
+      type: 'url',
+      confidence: 'exact',
+      count: 2,
+      books: [
+        {
+          bookId: 'b1',
+          name: 'Alpha',
+          size: 100,
+          author: null,
+          isbn: null,
+          language: 'turkish',
+        },
+        {
+          bookId: 'b2',
+          name: 'Küçük Prens, "Ciltli"',
+          size: 150,
+          author: '=SUM(A1)',
+          isbn: '9780000000000',
+          language: 'turkish',
+        },
+      ],
+    },
+  ],
+  totalGroups: 1,
+  page: 1,
+  limit: 20,
+  scannedBooks: 3,
+  totalBooks: 3,
+  isTruncated: false,
+  durationMs: 5,
+};
+
+const pagedReport: DuplicateAuditResult = { ...report, totalGroups: 45 };
+const pagedReportPage2: DuplicateAuditResult = { ...pagedReport, page: 2 };
+
+function createTestStore(isAdmin: boolean) {
+  const store = configureStore({
+    reducer: {
+      [commonApi.reducerPath]: commonApi.reducer,
+      authSlice: authReducer,
+    },
+    middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(commonApi.middleware),
+  });
+  store.dispatch(
+    loadUser({
+      user: {
+        id: 'user-1',
+        username: isAdmin ? 'admin' : 'user',
+        email: isAdmin ? 'admin@example.com' : 'user@example.com',
+        isAdmin,
+      },
+    })
+  );
+  return store;
+}
+
+function renderAudit(isAdmin = true) {
+  const store = createTestStore(isAdmin);
+  const ui = (
+    <Provider store={store}>
+      <MemoryRouter initialEntries={['/admin/duplicate-audit']}>
+        <Routes>
+          <Route path="/" element={<div>Home Page</div>} />
+          <Route path="/admin/duplicate-audit" element={<AdminDuplicateAudit />} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>
+  );
+  render(ui);
+  return { store };
+}
+
+describe('AdminDuplicateAudit', () => {
+  beforeEach(() => {
+    apiMocks.reset();
+  });
+
+  afterEach(() => {
+    Reflect.deleteProperty(URL, 'createObjectURL');
+    Reflect.deleteProperty(URL, 'revokeObjectURL');
+    vi.restoreAllMocks();
+  });
+
+  it('redirects non-admin users away without firing a request', () => {
+    renderAudit(false);
+
+    expect(screen.getByText('Home Page')).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Duplicate Audit' })).not.toBeInTheDocument();
+    expect(apiMocks.trigger).not.toHaveBeenCalled();
+  });
+
+  it('does not fire a request until Run Audit is clicked', async () => {
+    const user = userEvent.setup();
+    renderAudit();
+
+    expect(apiMocks.trigger).not.toHaveBeenCalled();
+    expect(screen.getByText(/Run an audit to detect duplicate books/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Run Audit' }));
+
+    expect(apiMocks.trigger).toHaveBeenCalledTimes(1);
+    expect(apiMocks.trigger).toHaveBeenCalledWith({ type: 'url', page: 1, limit: 20 });
+  });
+
+  it('renders summary cards and the grouped table after running', async () => {
+    const user = userEvent.setup();
+    apiMocks.state.data = report;
+    renderAudit();
+
+    await user.click(screen.getByRole('button', { name: 'Run Audit' }));
+
+    expect(screen.getByTestId('summary-url')).toHaveTextContent('1');
+    expect(screen.getByTestId('summary-isbn')).toHaveTextContent('0');
+    expect(screen.getByTestId('summary-name-size')).toHaveTextContent('0');
+    expect(screen.getByTestId('summary-title-author-language')).toHaveTextContent('0');
+    expect(screen.getByTestId('summary-scanned')).toHaveTextContent('3');
+    expect(screen.getByTestId('summary-total-groups')).toHaveTextContent('1');
+    expect(screen.queryByTestId('truncated-warning')).not.toBeInTheDocument();
+
+    // The group key and the confidence badge repeat once per book row inside
+    // the group, so scope the queries to the table and use plural getters for
+    // those duplicated values.
+    const table = screen.getByRole('table');
+    expect(within(table).getAllByText('a1b2c3d4e5f60718')).toHaveLength(2);
+    expect(within(table).getByText('Alpha')).toBeInTheDocument();
+    expect(within(table).getByText('Küçük Prens, "Ciltli"')).toBeInTheDocument();
+    expect(within(table).getAllByText('exact', { exact: true })).toHaveLength(2);
+    expect(within(table).getByRole('columnheader', { name: 'Group Key' })).toBeInTheDocument();
+  });
+
+  it('passes the next page when navigating pagination', async () => {
+    const user = userEvent.setup();
+    apiMocks.state.data = pagedReport;
+    renderAudit();
+
+    expect(screen.getByText(/Page 1 of 3/)).toBeInTheDocument();
+
+    apiMocks.state.data = pagedReportPage2;
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+
+    expect(apiMocks.trigger).toHaveBeenCalledTimes(1);
+    expect(apiMocks.trigger).toHaveBeenCalledWith({ type: 'url', page: 2, limit: 20 });
+
+    expect(screen.getByText(/Page 2 of 3/)).toBeInTheDocument();
+  });
+
+  it('warns when the bounded scan is incomplete', async () => {
+    const user = userEvent.setup();
+    apiMocks.state.data = { ...report, isTruncated: true, scannedBooks: 5000, totalBooks: 10000 };
+    renderAudit();
+
+    await user.click(screen.getByRole('button', { name: 'Run Audit' }));
+
+    const warning = screen.getByTestId('truncated-warning');
+    expect(warning).toHaveTextContent('Scan limit reached');
+    expect(warning).toHaveTextContent('5,000 of 10,000 books');
+  });
+
+  it('downloads sanitized JSON and CSV exports', async () => {
+    const user = userEvent.setup();
+    apiMocks.state.data = report;
+    renderAudit();
+
+    const createObjectURL = vi.fn(() => 'blob:mock-download');
+    const revokeObjectURL = vi.fn();
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      writable: true,
+      value: createObjectURL,
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      writable: true,
+      value: revokeObjectURL,
+    });
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+
+    await user.click(screen.getByRole('button', { name: 'Download JSON' }));
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    const jsonBlob = firstObjectUrlBlob(createObjectURL);
+    const jsonText = await readBlobAsText(jsonBlob);
+    const parsed = JSON.parse(jsonText) as DuplicateAuditResult;
+
+    expect(parsed.groups[0].books[0]).toEqual({
+      bookId: 'b1',
+      name: 'Alpha',
+      size: 100,
+      author: null,
+      isbn: null,
+      language: 'turkish',
+    });
+    expect(jsonText).not.toContain('uploader');
+    expect(jsonText).not.toContain('email');
+    expect(jsonText).not.toContain('http');
+
+    createObjectURL.mockClear();
+    clickSpy.mockClear();
+
+    await user.click(screen.getByRole('button', { name: 'Download CSV' }));
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    const csvBlob = firstObjectUrlBlob(createObjectURL);
+    const csvText = await readBlobAsText(csvBlob);
+
+    expect(csvText).toContain(
+      'Group Key,Reason,Confidence,Count,Book ID,Name,Author,ISBN,Language,Size'
+    );
+    expect(csvText).toContain('"Küçük Prens, ""Ciltli"""');
+    expect(csvText).toContain("'=SUM(A1)");
+    expect(csvText).not.toContain('uploader');
+    expect(csvText).not.toContain('email');
+    expect(csvText).not.toContain('http');
+  });
+});

--- a/client/src/redux/services/duplicateAudit.api.ts
+++ b/client/src/redux/services/duplicateAudit.api.ts
@@ -1,0 +1,58 @@
+import { commonApi } from '../common.api';
+
+export type DuplicateAuditType = 'url' | 'isbn' | 'name-size' | 'title-author-language';
+
+export type DuplicateAuditConfidence = 'exact' | 'soft';
+
+export interface DuplicateAuditBookItem {
+  bookId: string;
+  name: string;
+  size?: number;
+  author: string | null;
+  isbn: string | null;
+  language: string;
+}
+
+export interface DuplicateAuditGroup {
+  key: string;
+  type: DuplicateAuditType;
+  confidence: DuplicateAuditConfidence;
+  count: number;
+  books: DuplicateAuditBookItem[];
+}
+
+export type DuplicateAuditSummary = Record<DuplicateAuditType, number>;
+
+export interface DuplicateAuditResult {
+  type: DuplicateAuditType;
+  summary: DuplicateAuditSummary;
+  groups: DuplicateAuditGroup[];
+  totalGroups: number;
+  page: number;
+  limit: number;
+  scannedBooks: number;
+  totalBooks: number;
+  isTruncated: boolean;
+  durationMs: number;
+}
+
+export interface DuplicateAuditQueryArgs {
+  type: DuplicateAuditType;
+  page?: number;
+  limit?: number;
+}
+
+export const duplicateAuditApi = commonApi.injectEndpoints({
+  endpoints: (build) => ({
+    // GET /api/duplicate-audit?type=url&page=1&limit=20
+    // Lazy: only fired when an admin explicitly runs an audit.
+    getDuplicateAudit: build.query<DuplicateAuditResult, DuplicateAuditQueryArgs>({
+      query: ({ type, page = 1, limit = 20 }) => ({
+        url: '/duplicate-audit',
+        params: { type, page, limit },
+      }),
+    }),
+  }),
+});
+
+export const { useLazyGetDuplicateAuditQuery } = duplicateAuditApi;

--- a/client/tests/duplicate-audit.spec.ts
+++ b/client/tests/duplicate-audit.spec.ts
@@ -1,0 +1,109 @@
+import { expect, test } from '@playwright/test';
+import { blockExternalRequests } from './fixtures/external-block.fixture';
+
+const MOCK_AUDIT_REPORT = {
+  type: 'url',
+  summary: { url: 1, isbn: 0, 'name-size': 0, 'title-author-language': 0 },
+  groups: [
+    {
+      key: 'a1b2c3d4e5f60718',
+      type: 'url',
+      confidence: 'exact',
+      count: 2,
+      books: [
+        {
+          bookId: 'b1',
+          name: 'Alpha',
+          size: 100,
+          author: null,
+          isbn: null,
+          language: 'turkish',
+        },
+        {
+          bookId: 'b2',
+          name: 'Küçük Prens, "Ciltli"',
+          size: 150,
+          author: '=SUM(A1)',
+          isbn: '9780000000000',
+          language: 'turkish',
+        },
+      ],
+    },
+  ],
+  totalGroups: 1,
+  page: 1,
+  limit: 20,
+  scannedBooks: 3,
+  totalBooks: 3,
+  isTruncated: false,
+  durationMs: 5,
+};
+
+test.describe('Duplicate audit', () => {
+  let auditRequestCount = 0;
+
+  test.beforeEach(async ({ page }) => {
+    auditRequestCount = 0;
+
+    // Register API mocks BEFORE the global external block so they take
+    // priority under Playwright's reverse registration order.
+    await page.route('**/api/user/auth', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          user: {
+            id: 'admin-1',
+            username: 'admin',
+            email: 'admin@kitapkurdu.test',
+            isAdmin: true,
+          },
+        }),
+      });
+    });
+
+    await page.route('**/api/duplicate-audit**', async (route) => {
+      auditRequestCount += 1;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_AUDIT_REPORT),
+      });
+    });
+
+    await blockExternalRequests(page);
+  });
+
+  test('admin runs a duplicate audit and sees summary, table, and book names', async ({ page }) => {
+    await page.goto('/admin/duplicate-audit');
+
+    await expect(page.getByRole('heading', { name: 'Duplicate Audit' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Run Audit' })).toBeVisible();
+    await expect(page.getByText(/No request is sent until you click Run/)).toBeVisible();
+    expect(auditRequestCount).toBe(0);
+
+    await page.getByRole('button', { name: 'Run Audit' }).click();
+
+    // Summary cards render only after the audit request completes.
+    await expect(page.getByTestId('summary-url')).toContainText('1');
+    await expect(page.getByTestId('summary-isbn')).toContainText('0');
+    await expect(page.getByTestId('summary-name-size')).toContainText('0');
+    await expect(page.getByTestId('summary-title-author-language')).toContainText('0');
+    await expect(page.getByTestId('summary-scanned')).toContainText('3');
+    await expect(page.getByTestId('summary-total-groups')).toContainText('1');
+
+    expect(auditRequestCount).toBe(1);
+
+    const table = page.getByRole('table');
+    await expect(table).toBeVisible();
+    await expect(table.getByRole('columnheader', { name: 'Group Key' })).toBeVisible();
+    await expect(table.getByText('Alpha')).toBeVisible();
+    await expect(table.getByText('Küçük Prens, "Ciltli"')).toBeVisible();
+
+    // The audit report must not leak raw http/uploader/email text into main.
+    const main = page.locator('main#main-content');
+    await expect(main).not.toContainText('http');
+    await expect(main).not.toContainText('uploader');
+    await expect(main).not.toContainText('email');
+  });
+});


### PR DESCRIPTION
## Summary
- add an explicit admin-only read-only duplicate audit
- group exact URL hashes, ISBN, normalized name+size, and soft title+author+language candidates
- add sanitized paginated UI plus current-page JSON/CSV export
- surface the 10,000-book scan bound instead of silently claiming completeness

## Safety
- GET/read-only Books.find + countDocuments only
- no Book writes/deletes/merges, schema/index/migration/backfill, Cloudinary access, or automatic decisions
- raw URLs, uploader data and email are never selected/returned/exported

## Verification
- backend 60 tests; client 65 tests; E2E 8; builds/Biome pass

## Next gate
Operator reviews real report counts before any enforcement/backfill/index issue.

Closes #377