### PR TITLE
fix: extend access token session to eight hours

### DIFF
--- a/backend/controllers/user.controller.ts
+++ b/backend/controllers/user.controller.ts
@@ -1,8 +1,13 @@
-import { Request, Response, CookieOptions } from 'express';
-import { logoutUser, registerUser } from '../services/user';
+import type { CookieOptions, Request, Response } from 'express';
 import { CustomError } from '../errors/custom-error';
-import { generateAccessToken, generateRefreshToken } from '../utils/jwt.utils';
 import { logger } from '../logger';
+import { logoutUser, registerUser } from '../services/user';
+import {
+  ACCESS_TOKEN_MAX_AGE_MS,
+  generateAccessToken,
+  generateRefreshToken,
+  REFRESH_TOKEN_MAX_AGE_MS,
+} from '../utils/jwt.utils';
 
 // Base cookie options for auth cookies (cross-site friendly in production)
 const cookieBaseOptions: CookieOptions = {
@@ -23,12 +28,12 @@ export const loginController = async (req: Request, res: Response) => {
 
     res.cookie('refreshToken', refreshToken, {
       ...cookieBaseOptions,
-      maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
+      maxAge: REFRESH_TOKEN_MAX_AGE_MS, // 7 days
     });
 
     res.cookie('accessToken', accessToken, {
       ...cookieBaseOptions,
-      maxAge: 15 * 60 * 1000, // 15 minutes
+      maxAge: ACCESS_TOKEN_MAX_AGE_MS, // 8 hours
     });
 
     res.status(200).json({
@@ -158,7 +163,7 @@ export const refreshTokenController = async (req: Request, res: Response) => {
         hasRefreshTokenCookie: !!req.cookies?.refreshToken,
         hasRTParam: !!req.query?.rt,
         userAgent: req.headers['user-agent'],
-        origin: req.headers.origin
+        origin: req.headers.origin,
       });
     }
 
@@ -171,7 +176,7 @@ export const refreshTokenController = async (req: Request, res: Response) => {
       }
       return res.status(401).json({
         success: false,
-        message: 'No user found - refresh token invalid or expired'
+        message: 'No user found - refresh token invalid or expired',
       });
     }
 
@@ -187,7 +192,7 @@ export const refreshTokenController = async (req: Request, res: Response) => {
 
     res.cookie('accessToken', newAccessToken, {
       ...cookieBaseOptions,
-      maxAge: 15 * 60 * 1000, // 15 minutes
+      maxAge: ACCESS_TOKEN_MAX_AGE_MS, // 8 hours
     });
 
     if (process.env.NODE_ENV !== 'production') {
@@ -211,7 +216,12 @@ export const refreshTokenController = async (req: Request, res: Response) => {
   } catch (error) {
     logger.error('Error in refresh token controller', {
       error: error instanceof Error ? error.message : 'Unknown error',
-      stack: process.env.NODE_ENV !== 'production' ? (error instanceof Error ? error.stack : undefined) : undefined
+      stack:
+        process.env.NODE_ENV !== 'production'
+          ? error instanceof Error
+            ? error.stack
+            : undefined
+          : undefined,
     });
     res.status(500).json({
       success: false,

--- a/backend/routes/api/user.ts
+++ b/backend/routes/api/user.ts
@@ -14,7 +14,12 @@ import {
 } from '../../controllers/user.controller';
 import { auth } from '../../middleware/auth';
 import { validateRequest } from '../../middleware/validate-request';
-import { generateAccessToken, generateRefreshToken } from '../../utils/jwt.utils';
+import {
+  ACCESS_TOKEN_MAX_AGE_MS,
+  generateAccessToken,
+  generateRefreshToken,
+  REFRESH_TOKEN_MAX_AGE_MS,
+} from '../../utils/jwt.utils';
 
 const router = express.Router();
 
@@ -83,12 +88,12 @@ router.get(
 
     res.cookie('refreshToken', refreshToken, {
       ...cookieOptions,
-      maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
+      maxAge: REFRESH_TOKEN_MAX_AGE_MS, // 7 days
     });
 
     res.cookie('accessToken', accessToken, {
       ...cookieOptions,
-      maxAge: 15 * 60 * 1000, // 15 minutes
+      maxAge: ACCESS_TOKEN_MAX_AGE_MS, // 8 hours
     });
 
     const clientUrl = process.env.CLIENT_URL || 'http://localhost:3000';

--- a/backend/utils/__test__/jwt.utils.test.ts
+++ b/backend/utils/__test__/jwt.utils.test.ts
@@ -1,0 +1,39 @@
+import jwt from 'jsonwebtoken';
+import {
+  ACCESS_TOKEN_MAX_AGE_MS,
+  generateAccessToken,
+  generateRefreshToken,
+  REFRESH_TOKEN_MAX_AGE_MS,
+} from '../jwt.utils';
+
+const payload = {
+  _id: 'test-id',
+  username: 'test',
+  email: 'test@test.com',
+  isAdmin: false,
+};
+
+describe('jwt.utils token lifetimes', () => {
+  it('issues access tokens that expire exactly 8 hours after issue', () => {
+    const token = generateAccessToken(payload);
+    const decoded = jwt.decode(token) as jwt.JwtPayload;
+    const lifetimeSeconds = (decoded.exp as number) - (decoded.iat as number);
+
+    expect(lifetimeSeconds).toBe(8 * 60 * 60);
+    expect(lifetimeSeconds).toBe(ACCESS_TOKEN_MAX_AGE_MS / 1000);
+  });
+
+  it('issues refresh tokens that expire exactly 7 days after issue', () => {
+    const token = generateRefreshToken(payload);
+    const decoded = jwt.decode(token) as jwt.JwtPayload;
+    const lifetimeSeconds = (decoded.exp as number) - (decoded.iat as number);
+
+    expect(lifetimeSeconds).toBe(7 * 24 * 60 * 60);
+    expect(lifetimeSeconds).toBe(REFRESH_TOKEN_MAX_AGE_MS / 1000);
+  });
+
+  it('keeps cookie max-ages aligned with token lifetimes', () => {
+    expect(ACCESS_TOKEN_MAX_AGE_MS).toBe(8 * 60 * 60 * 1000);
+    expect(REFRESH_TOKEN_MAX_AGE_MS).toBe(7 * 24 * 60 * 60 * 1000);
+  });
+});

--- a/backend/utils/jwt.utils.ts
+++ b/backend/utils/jwt.utils.ts
@@ -1,4 +1,4 @@
-import jwt, { JwtPayload } from 'jsonwebtoken';
+import jwt, { type JwtPayload } from 'jsonwebtoken';
 
 // Validate JWT secrets at module load time
 const ACCESS_TOKEN_SECRET = process.env.ACCESS_TOKEN_SECRET_KEY;
@@ -12,26 +12,23 @@ if (!REFRESH_TOKEN_SECRET) {
   throw new Error('REFRESH_TOKEN_SECRET_KEY environment variable is required');
 }
 
+// Cookie max-ages must stay aligned with the JWT expirations below so cookie
+// lifetimes cannot drift from token lifetimes.
+export const ACCESS_TOKEN_MAX_AGE_MS = 8 * 60 * 60 * 1000; // 8 hours
+export const REFRESH_TOKEN_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
 const generateAccessToken = (payload: JwtPayload) => {
   const { _id, username, email, isAdmin = false } = payload;
-  return jwt.sign(
-    { _id, username, email, isAdmin },
-    ACCESS_TOKEN_SECRET,
-    {
-      expiresIn: '15m',
-    }
-  );
+  return jwt.sign({ _id, username, email, isAdmin }, ACCESS_TOKEN_SECRET, {
+    expiresIn: '8h',
+  });
 };
 
 const generateRefreshToken = (payload: JwtPayload) => {
   const { _id, username, email, isAdmin = false } = payload;
-  return jwt.sign(
-    { _id, username, email, isAdmin },
-    REFRESH_TOKEN_SECRET,
-    {
-      expiresIn: '7d',
-    }
-  );
+  return jwt.sign({ _id, username, email, isAdmin }, REFRESH_TOKEN_SECRET, {
+    expiresIn: '7d',
+  });
 };
 
 const verifyAccessToken = (token: string) => {

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,8 +6,7 @@ import Layout from './components/Layout';
 import { Search } from './components/Search';
 import { loadUserThunk } from './redux/authSlice';
 import { apiBaseUrl } from './redux/common.api';
-import { useAppDispatch, useAppSelector } from './redux/store';
-import { handleAuthExpiredOnce, refreshAccessToken } from './redux/tokenRefresh';
+import { useAppDispatch } from './redux/store';
 
 ReactGA.initialize('G-R54SYJD2B8');
 
@@ -108,30 +107,10 @@ function App() {
   const location = useLocation();
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
-  const { isLoggedIn } = useAppSelector((state) => state.authSlice);
 
   useEffect(() => {
     ReactGA.send({ hitType: 'pageview', page: location.pathname });
   }, [location.pathname]);
-
-  // Periodic token refresh for logged-in users (every 10 minutes)
-  useEffect(() => {
-    if (!isLoggedIn) return;
-
-    const interval = setInterval(
-      () => {
-        void refreshAccessToken(apiBaseUrl).then((result) => {
-          if (result.status === 'auth-expired') {
-            handleAuthExpiredOnce(dispatch);
-          }
-          // Network errors are best-effort: keep the session for the next tick.
-        });
-      },
-      10 * 60 * 1000
-    ); // 10 minutes
-
-    return () => clearInterval(interval);
-  }, [isLoggedIn, dispatch]);
 
   // After Google OAuth redirect (?auth=success), load user from backend and clean URL
   useEffect(() => {


### PR DESCRIPTION
8h JWT+cookies, remove proactive 10m timer, retain reactive single-flight and 7d refresh, security tradeoff/no DB; verification backend63/client65/E2E8/build/Biome.

Closes #380.