### PR TITLE
feat: add reversible duplicate soft-hide

### DIFF
--- a/backend/app.ts
+++ b/backend/app.ts
@@ -46,7 +46,8 @@ app.use('/api', routes);
 app.get('/og/book/:id', async (req: Request, res: Response) => {
   try {
     const { id } = req.params as { id: string };
-    const book = await Books.findById(id).lean();
+    // Soft-hidden duplicates get no preview card either.
+    const book = await Books.findOne({ _id: id, duplicateOf: null }).lean();
     if (!book) {
       return res.status(404).send('Not found');
     }
@@ -100,7 +101,7 @@ app.get('/sitemap.xml', async (req: Request, res: Response) => {
     const origin = process.env.CLIENT_URL || `${req.protocol}://${req.get('host')}`;
     const staticUrls = ['/', '/all-books', '/recently-added'];
 
-    const books = await Books.find({}, { _id: 1, date: 1 }).lean();
+    const books = await Books.find({ duplicateOf: null }, { _id: 1, date: 1 }).lean();
     const urls: Array<{ loc: string; lastmod?: string }> = [
       ...staticUrls.map((path) => ({ loc: `${origin}${path}` })),
       ...books.map((b: any) => ({

--- a/backend/controllers/duplicateAudit.controller.ts
+++ b/backend/controllers/duplicateAudit.controller.ts
@@ -5,6 +5,10 @@ import {
   DUPLICATE_AUDIT_TYPES,
   runDuplicateAuditService,
 } from '../services/duplicateAudit/duplicateAudit.service';
+import {
+  markDuplicateService,
+  unmarkDuplicateService,
+} from '../services/duplicateAudit/duplicateMark.service';
 
 const MAX_LIMIT = 50;
 const DEFAULT_LIMIT = 20;
@@ -51,6 +55,28 @@ export const getDuplicateAuditController = async (
       limit: limit ?? DEFAULT_LIMIT,
     });
 
+    res.status(200).json(result);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const markDuplicateController = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const result = await markDuplicateService(req.body);
+    res.status(200).json(result);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const unmarkDuplicateController = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    const result = await unmarkDuplicateService(req.body);
     res.status(200).json(result);
   } catch (err) {
     next(err);

--- a/backend/controllers/ratings.controller.ts
+++ b/backend/controllers/ratings.controller.ts
@@ -1,9 +1,28 @@
-import { Request, Response } from 'express';
+import type { NextFunction, Request, Response } from 'express';
+import mongoose from 'mongoose';
+import { NotFoundError } from '../errors/not-found-error';
+import { Books } from '../models/Books';
 import { Rating } from '../models/Rating';
+
+/**
+ * A soft-hidden duplicate must not expose a rating summary/reviews nor accept
+ * new ratings. Both the public read routes and the authenticated write route
+ * require the target book to exist and to be public (duplicateOf: null).
+ */
+const ensurePublicBook = async (bookId: string): Promise<void> => {
+  if (!mongoose.isValidObjectId(bookId)) {
+    throw new NotFoundError('Book not found');
+  }
+  const book = await Books.exists({ _id: bookId, duplicateOf: null });
+  if (!book) {
+    throw new NotFoundError('Book not found');
+  }
+};
 
 export const createOrUpdateRatingController = async (
   req: Request,
-  res: Response
+  res: Response,
+  next: NextFunction
 ) => {
   try {
     const userId = (req.user as any)?._id;
@@ -13,6 +32,8 @@ export const createOrUpdateRatingController = async (
       review?: string;
     };
 
+    await ensurePublicBook(bookId);
+
     const doc = await Rating.findOneAndUpdate(
       { bookId, userId },
       { $set: { rating, review } },
@@ -20,19 +41,23 @@ export const createOrUpdateRatingController = async (
     );
 
     res.status(200).json({ success: true, data: doc });
-  } catch (err: any) {
-    res.status(500).json({ success: false, message: err.message });
+  } catch (err) {
+    next(err);
   }
 };
 
 export const getBookRatingsSummaryController = async (
   req: Request,
-  res: Response
+  res: Response,
+  next: NextFunction
 ) => {
   try {
     const { bookId } = req.params as { bookId: string };
+
+    await ensurePublicBook(bookId);
+
     const [summary] = await Rating.aggregate([
-      { $match: { bookId: new (require('mongoose').Types.ObjectId)(bookId) } },
+      { $match: { bookId: new mongoose.Types.ObjectId(bookId) } },
       {
         $group: {
           _id: '$bookId',
@@ -42,23 +67,24 @@ export const getBookRatingsSummaryController = async (
       },
     ]);
 
-    res
-      .status(200)
-      .json({ success: true, data: summary || { avgRating: 0, count: 0 } });
-  } catch (err: any) {
-    res.status(500).json({ success: false, message: err.message });
+    res.status(200).json({ success: true, data: summary || { avgRating: 0, count: 0 } });
+  } catch (err) {
+    next(err);
   }
 };
 
-export const getBookReviewsController = async (req: Request, res: Response) => {
+export const getBookReviewsController = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const { bookId } = req.params as { bookId: string };
+
+    await ensurePublicBook(bookId);
+
     const reviews = await Rating.find({ bookId })
       .sort({ updatedAt: -1 })
       .limit(50)
       .populate('userId', 'username');
     res.status(200).json({ success: true, data: reviews });
-  } catch (err: any) {
-    res.status(500).json({ success: false, message: err.message });
+  } catch (err) {
+    next(err);
   }
 };

--- a/backend/models/Books.ts
+++ b/backend/models/Books.ts
@@ -58,6 +58,14 @@ export const schema = new mongoose.Schema(
       enum: ['turkish', 'english'],
       default: 'turkish',
     },
+    // Soft-hide: when set, this book is considered a duplicate of the
+    // referenced canonical book and is hidden from all public endpoints.
+    // Nullable and optional on purpose - no index, migration or backfill.
+    duplicateOf: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Books',
+      default: null,
+    },
   },
   { collection: 'ilkparti' }
 );
@@ -107,6 +115,7 @@ export interface IBook extends Document {
     thumbnail: string;
   };
   language: 'turkish' | 'english';
+  duplicateOf?: mongoose.Schema.Types.ObjectId | null;
 }
 
 export const Books = mongoose.model<IBook>('Books', schema);

--- a/backend/routes/api/__test__/books.test.ts
+++ b/backend/routes/api/__test__/books.test.ts
@@ -471,6 +471,37 @@ it('should allow admin users to delete books', async () => {
     .expect(200);
 });
 
+it('should block deleting a book that is the canonical of hidden duplicates', async () => {
+  const { accessToken } = await global.signin(true);
+  const canonical = await Books.create({
+    name: 'Canonical Book',
+    url: DUMMY_PDF_URL,
+    size: 100,
+  });
+  const duplicate = await Books.create({
+    name: 'Hidden Duplicate',
+    url: DUMMY_PDF_URL,
+    size: 100,
+    duplicateOf: canonical._id,
+  });
+
+  await request(app)
+    .post(`/api/books/deleteBook/${canonical._id}`)
+    .set('Cookie', `accessToken=${accessToken}`)
+    .expect(400);
+
+  // Neither the canonical nor its hidden duplicate was removed.
+  expect(await Books.exists({ _id: canonical._id })).toBeTruthy();
+  expect(await Books.exists({ _id: duplicate._id })).toBeTruthy();
+
+  // Once the duplicate is unmarked the canonical can be deleted.
+  await Books.updateOne({ _id: duplicate._id }, { $set: { duplicateOf: null } });
+  await request(app)
+    .post(`/api/books/deleteBook/${canonical._id}`)
+    .set('Cookie', `accessToken=${accessToken}`)
+    .expect(200);
+});
+
 it('should get all books paginated', async () => {
   const { accessToken, sender } = await global.signin();
   const book1 = await request(app)

--- a/backend/routes/api/__test__/duplicateAudit.test.ts
+++ b/backend/routes/api/__test__/duplicateAudit.test.ts
@@ -71,6 +71,7 @@ describe('GET /api/duplicate-audit', () => {
     expect(Object.keys(res.body.groups[0].books[0]).sort()).toEqual([
       'author',
       'bookId',
+      'duplicateOf',
       'isbn',
       'language',
       'name',

--- a/backend/routes/api/__test__/duplicateMark.test.ts
+++ b/backend/routes/api/__test__/duplicateMark.test.ts
@@ -1,0 +1,427 @@
+import mongoose from 'mongoose';
+import request from 'supertest';
+import { app } from '../../../app';
+import { Books } from '../../../models/Books';
+import { Rating } from '../../../models/Rating';
+
+const getCookie = async (isAdmin = true) => {
+  const { accessToken } = await global.signin(isAdmin);
+  return `accessToken=${accessToken}`;
+};
+
+const makeBook = (overrides: Record<string, unknown> = {}) =>
+  Books.create({
+    name: 'Book',
+    url: `https://example.com/${Math.random().toString(36).slice(2)}.pdf`,
+    size: 100,
+    ...overrides,
+  });
+
+const markBody = (canonicalId: string, duplicateIds: string[]) => ({
+  canonicalId,
+  duplicateIds,
+});
+
+const missingId = () => String(new mongoose.Types.ObjectId());
+
+const searchNames = async (q: string) => {
+  const res = await request(app).get('/api/books/search').query({ q }).expect(200);
+  return res.body.results.map((book: { name: string }) => book.name);
+};
+
+describe('POST /api/duplicate-audit/mark', () => {
+  it('returns 401 when unauthenticated and 403 for non-admin users', async () => {
+    const canonical = await makeBook();
+    const dup = await makeBook();
+    const body = markBody(String(canonical._id), [String(dup._id)]);
+
+    await request(app).post('/api/duplicate-audit/mark').send(body).expect(401);
+
+    const cookie = await getCookie(false);
+    await request(app)
+      .post('/api/duplicate-audit/mark')
+      .set('Cookie', cookie)
+      .send(body)
+      .expect(403);
+  });
+
+  it('rejects malformed bodies and invalid ids', async () => {
+    const cookie = await getCookie();
+    const book = await makeBook();
+    const id = String(book._id);
+
+    const badBodies = [
+      {},
+      { canonicalId: '' },
+      { canonicalId: 123, duplicateIds: [id] },
+      { canonicalId: id, duplicateIds: 'not-an-array' },
+      { canonicalId: id, duplicateIds: [] },
+      { canonicalId: id, duplicateIds: [123] },
+    ];
+    for (const body of badBodies) {
+      const res = await request(app)
+        .post('/api/duplicate-audit/mark')
+        .set('Cookie', cookie)
+        .send(body)
+        .expect(400);
+      expect(res.body.errors).toBeDefined();
+    }
+
+    for (const badId of ['not-an-object-id', '123']) {
+      await request(app)
+        .post('/api/duplicate-audit/mark')
+        .set('Cookie', cookie)
+        .send(markBody(id, [badId]))
+        .expect(400);
+    }
+  });
+
+  it('rejects batches larger than 50 duplicates', async () => {
+    const cookie = await getCookie();
+    const canonical = await makeBook();
+    const dup = await makeBook();
+    const tooMany = Array.from({ length: 51 }, () => String(dup._id));
+
+    const res = await request(app)
+      .post('/api/duplicate-audit/mark')
+      .set('Cookie', cookie)
+      .send(markBody(String(canonical._id), tooMany))
+      .expect(400);
+
+    expect(res.body.errors[0].message).toContain('50');
+  });
+
+  it('returns 404 when the canonical or a duplicate does not exist', async () => {
+    const cookie = await getCookie();
+    const canonical = await makeBook();
+    const dup = await makeBook();
+
+    await request(app)
+      .post('/api/duplicate-audit/mark')
+      .set('Cookie', cookie)
+      .send(markBody(missingId(), [String(dup._id)]))
+      .expect(404);
+
+    await request(app)
+      .post('/api/duplicate-audit/mark')
+      .set('Cookie', cookie)
+      .send(markBody(String(canonical._id), [missingId()]))
+      .expect(404);
+  });
+
+  it('rejects marking a book as its own duplicate', async () => {
+    const cookie = await getCookie();
+    const book = await makeBook();
+
+    await request(app)
+      .post('/api/duplicate-audit/mark')
+      .set('Cookie', cookie)
+      .send(markBody(String(book._id), [String(book._id)]))
+      .expect(400);
+  });
+
+  it('rejects a canonical that is already hidden as a duplicate', async () => {
+    const cookie = await getCookie();
+    const bookA = await makeBook();
+    const bookB = await makeBook();
+    const bookC = await makeBook();
+
+    await request(app)
+      .post('/api/duplicate-audit/mark')
+      .set('Cookie', cookie)
+      .send(markBody(String(bookB._id), [String(bookA._id)]))
+      .expect(200);
+
+    await request(app)
+      .post('/api/duplicate-audit/mark')
+      .set('Cookie', cookie)
+      .send(markBody(String(bookC._id), [String(bookB._id)]))
+      .expect(400);
+  });
+
+  it('rejects hiding a book that is the canonical of another marked book (prevents chains)', async () => {
+    const cookie = await getCookie();
+    const canonical = await makeBook();
+    const dup = await makeBook();
+    const grandchild = await makeBook();
+
+    await request(app)
+      .post('/api/duplicate-audit/mark')
+      .set('Cookie', cookie)
+      .send(markBody(String(dup._id), [String(grandchild._id)]))
+      .expect(200);
+
+    await request(app)
+      .post('/api/duplicate-audit/mark')
+      .set('Cookie', cookie)
+      .send(markBody(String(canonical._id), [String(dup._id)]))
+      .expect(400);
+  });
+
+  it('rejects repointing a duplicate already hidden under another canonical', async () => {
+    const cookie = await getCookie();
+    const canonicalA = await makeBook();
+    const canonicalB = await makeBook();
+    const dup = await makeBook();
+
+    await request(app)
+      .post('/api/duplicate-audit/mark')
+      .set('Cookie', cookie)
+      .send(markBody(String(canonicalA._id), [String(dup._id)]))
+      .expect(200);
+
+    // dup is already hidden under A; silently moving it under B must fail.
+    const res = await request(app)
+      .post('/api/duplicate-audit/mark')
+      .set('Cookie', cookie)
+      .send(markBody(String(canonicalB._id), [String(dup._id)]))
+      .expect(400);
+
+    expect(res.body.errors[0].message).toContain('unmark');
+
+    // The original mapping is untouched.
+    const stored = await Books.findById(dup._id).lean();
+    expect(String(stored?.duplicateOf)).toBe(String(canonicalA._id));
+  });
+
+  it('marks duplicates under the canonical and hides them from every public endpoint', async () => {
+    const cookie = await getCookie();
+    const canonical = await makeBook({ name: 'Canonical Book' });
+    const dupA = await makeBook({ name: 'Duplicate A' });
+    const dupB = await makeBook({ name: 'Duplicate B' });
+
+    const res = await request(app)
+      .post('/api/duplicate-audit/mark')
+      .set('Cookie', cookie)
+      .send(markBody(String(canonical._id), [String(dupA._id), String(dupB._id)]))
+      .expect(200);
+
+    expect(res.body).toEqual({
+      canonicalId: String(canonical._id),
+      duplicateIds: [String(dupA._id), String(dupB._id)],
+      updatedCount: 2,
+    });
+
+    const stored = await Books.find({ _id: { $in: [dupA._id, dupB._id] } }).lean();
+    for (const book of stored) {
+      expect(String(book.duplicateOf)).toBe(String(canonical._id));
+    }
+
+    expect(await searchNames('Duplicate')).toEqual([]);
+
+    const allBooks = await request(app)
+      .get('/api/books/allBooks')
+      .query({ language: 'all', page: 1, limit: 20 })
+      .expect(200);
+    expect(allBooks.body.data.results.map((b: { name: string }) => b.name)).toEqual([
+      'Canonical Book',
+    ]);
+
+    const recent = await request(app)
+      .get('/api/books/recently-added')
+      .query({ page: 1, limit: 20 })
+      .expect(200);
+    expect(recent.body.data.books.map((b: { name: string }) => b.name)).toEqual(['Canonical Book']);
+
+    // Detail returns an empty body for hidden books (the client renders not-found).
+    const hiddenDetail = await request(app).get(`/api/books/getBookById/${dupA._id}`).expect(200);
+    expect(hiddenDetail.body).toBeNull();
+    await request(app).get(`/og/book/${dupA._id}`).expect(404);
+
+    const sitemap = await request(app).get('/sitemap.xml').expect(200);
+    expect(sitemap.text).toContain(`/book/${canonical._id}`);
+    expect(sitemap.text).not.toContain(`/book/${dupA._id}`);
+    expect(sitemap.text).not.toContain(`/book/${dupB._id}`);
+
+    const detail = await request(app).get(`/api/books/getBookById/${canonical._id}`).expect(200);
+    expect(detail.body.name).toBe('Canonical Book');
+  });
+
+  it('is idempotent when the same duplicates are marked again', async () => {
+    const cookie = await getCookie();
+    const canonical = await makeBook();
+    const dup = await makeBook();
+
+    await request(app)
+      .post('/api/duplicate-audit/mark')
+      .set('Cookie', cookie)
+      .send(markBody(String(canonical._id), [String(dup._id)]))
+      .expect(200);
+
+    const res = await request(app)
+      .post('/api/duplicate-audit/mark')
+      .set('Cookie', cookie)
+      .send(markBody(String(canonical._id), [String(dup._id)]))
+      .expect(200);
+
+    expect(res.body.updatedCount).toBe(0);
+  });
+});
+
+describe('POST /api/duplicate-audit/unmark', () => {
+  it('returns 401 when unauthenticated and 403 for non-admin users', async () => {
+    const dup = await makeBook();
+    const body = { duplicateIds: [String(dup._id)] };
+
+    await request(app).post('/api/duplicate-audit/unmark').send(body).expect(401);
+
+    const cookie = await getCookie(false);
+    await request(app)
+      .post('/api/duplicate-audit/unmark')
+      .set('Cookie', cookie)
+      .send(body)
+      .expect(403);
+  });
+
+  it('rejects malformed bodies', async () => {
+    const cookie = await getCookie();
+
+    const badBodies = [
+      {},
+      { duplicateIds: 'not-an-array' },
+      { duplicateIds: [] },
+      { duplicateIds: [123] },
+    ];
+    for (const body of badBodies) {
+      const res = await request(app)
+        .post('/api/duplicate-audit/unmark')
+        .set('Cookie', cookie)
+        .send(body)
+        .expect(400);
+      expect(res.body.errors).toBeDefined();
+    }
+  });
+
+  it('returns 404 when a book id does not exist', async () => {
+    const cookie = await getCookie();
+    await request(app)
+      .post('/api/duplicate-audit/unmark')
+      .set('Cookie', cookie)
+      .send({ duplicateIds: [missingId()] })
+      .expect(404);
+  });
+
+  it('restores unmarked books to every public endpoint and keeps others hidden', async () => {
+    const cookie = await getCookie();
+    const canonical = await makeBook({ name: 'Canonical Book' });
+    const dupA = await makeBook({ name: 'Duplicate A' });
+    const dupB = await makeBook({ name: 'Duplicate B' });
+
+    await request(app)
+      .post('/api/duplicate-audit/mark')
+      .set('Cookie', cookie)
+      .send(markBody(String(canonical._id), [String(dupA._id), String(dupB._id)]))
+      .expect(200);
+
+    const res = await request(app)
+      .post('/api/duplicate-audit/unmark')
+      .set('Cookie', cookie)
+      .send({ duplicateIds: [String(dupA._id)] })
+      .expect(200);
+
+    expect(res.body).toEqual({
+      duplicateIds: [String(dupA._id)],
+      updatedCount: 1,
+    });
+
+    expect(await searchNames('Duplicate')).toEqual(['Duplicate A']);
+
+    const detail = await request(app).get(`/api/books/getBookById/${dupA._id}`).expect(200);
+    expect(detail.body.name).toBe('Duplicate A');
+    await request(app).get(`/og/book/${dupA._id}`).expect(200);
+
+    const sitemap = await request(app).get('/sitemap.xml').expect(200);
+    expect(sitemap.text).toContain(`/book/${dupA._id}`);
+    expect(sitemap.text).not.toContain(`/book/${dupB._id}`);
+
+    const stillHidden = await request(app).get(`/api/books/getBookById/${dupB._id}`).expect(200);
+    expect(stillHidden.body).toBeNull();
+  });
+
+  it('is idempotent when unmarking books that are not marked', async () => {
+    const cookie = await getCookie();
+    const dup = await makeBook();
+
+    const res = await request(app)
+      .post('/api/duplicate-audit/unmark')
+      .set('Cookie', cookie)
+      .send({ duplicateIds: [String(dup._id)] })
+      .expect(200);
+
+    expect(res.body.updatedCount).toBe(0);
+  });
+});
+
+describe('mark/unmark data integrity', () => {
+  it('changes only duplicateOf and never deletes books or ratings', async () => {
+    const { accessToken, sender } = await global.signin(true);
+    const cookie = `accessToken=${accessToken}`;
+    const canonical = await makeBook({ name: 'Canonical' });
+    const dup = await makeBook({ name: 'Duplicate' });
+    await Rating.create({ bookId: canonical._id, userId: sender, rating: 5 });
+
+    const snapshot = async () => {
+      const docs = (await Books.find({}, null, { sort: { _id: 1 } }).lean()) as Array<
+        Record<string, unknown>
+      >;
+      return {
+        bookCount: await Books.countDocuments(),
+        ratingCount: await Rating.countDocuments(),
+        bookIds: docs.map((doc) => String(doc._id)).sort(),
+      };
+    };
+
+    const before = await snapshot();
+
+    await request(app)
+      .post('/api/duplicate-audit/mark')
+      .set('Cookie', cookie)
+      .send(markBody(String(canonical._id), [String(dup._id)]))
+      .expect(200);
+
+    await request(app)
+      .post('/api/duplicate-audit/unmark')
+      .set('Cookie', cookie)
+      .send({ duplicateIds: [String(dup._id)] })
+      .expect(200);
+
+    const after = await snapshot();
+
+    expect(after.bookCount).toBe(before.bookCount);
+    expect(after.ratingCount).toBe(before.ratingCount);
+    expect(after.bookIds).toEqual(before.bookIds);
+
+    const dupDoc = await Books.findById(dup._id).lean();
+    expect(dupDoc?.duplicateOf).toBeNull();
+  });
+
+  it('audit still includes marked books and reports their duplicateOf', async () => {
+    const cookie = await getCookie();
+    const canonical = await makeBook({ name: 'Same Name', size: 100 });
+    const dup = await makeBook({ name: 'Same Name', size: 100 });
+
+    await request(app)
+      .post('/api/duplicate-audit/mark')
+      .set('Cookie', cookie)
+      .send(markBody(String(canonical._id), [String(dup._id)]))
+      .expect(200);
+
+    const res = await request(app)
+      .get('/api/duplicate-audit?type=name-size')
+      .set('Cookie', cookie)
+      .expect(200);
+
+    expect(res.body.scannedBooks).toBe(2);
+    expect(res.body.totalBooks).toBe(2);
+    expect(res.body.summary['name-size']).toBe(1);
+    expect(res.body.groups[0].count).toBe(2);
+
+    const group = res.body.groups[0];
+    const dupItem = group.books.find((b: { bookId: string }) => b.bookId === String(dup._id));
+    const canonicalItem = group.books.find(
+      (b: { bookId: string }) => b.bookId === String(canonical._id)
+    );
+    expect(dupItem.duplicateOf).toBe(String(canonical._id));
+    expect(canonicalItem.duplicateOf).toBeNull();
+  });
+});

--- a/backend/routes/api/__test__/ratings.test.ts
+++ b/backend/routes/api/__test__/ratings.test.ts
@@ -1,0 +1,127 @@
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import request from 'supertest';
+import { app } from '../../../app';
+import { Books } from '../../../models/Books';
+import { Rating } from '../../../models/Rating';
+import { User } from '../../../models/User';
+
+const makeBook = (overrides: Record<string, unknown> = {}) =>
+  Books.create({
+    name: 'Book',
+    url: `https://example.com/${Math.random().toString(36).slice(2)}.pdf`,
+    size: 100,
+    ...overrides,
+  });
+
+const markBody = (canonicalId: string, duplicateIds: string[]) => ({
+  canonicalId,
+  duplicateIds,
+});
+
+// global.signin() always creates the same username/email, so a test that needs
+// both an admin and a regular user in the same database must mint its own
+// unique users instead.
+let userSeq = 0;
+const makeCookie = async (isAdmin = false) => {
+  userSeq += 1;
+  const hash = await bcrypt.hash('test', 10);
+  const user = await User.create({
+    username: `test-${userSeq}`,
+    email: `example${userSeq}@gmail.com`,
+    password: hash,
+    isAdmin,
+  });
+  const accessToken = jwt.sign(
+    { _id: user._id, isAdmin: user.isAdmin },
+    process.env.ACCESS_TOKEN_SECRET_KEY!,
+    { expiresIn: '85m' }
+  );
+  return `accessToken=${accessToken}`;
+};
+
+describe('ratings and hidden duplicates', () => {
+  it('refuses summary, reviews and rate writes for a hidden duplicate until it is unmarked', async () => {
+    const canonical = await makeBook({ name: 'Canonical Book' });
+    const dup = await makeBook({ name: 'Hidden Duplicate' });
+    const cookie = await makeCookie(true);
+    const authCookie = await makeCookie();
+
+    await request(app)
+      .post('/api/duplicate-audit/mark')
+      .set('Cookie', cookie)
+      .send(markBody(String(canonical._id), [String(dup._id)]))
+      .expect(200);
+
+    // Public read routes return the existing not-found pattern for the hidden book.
+    await request(app).get(`/api/ratings/summary/${dup._id}`).expect(404);
+    await request(app).get(`/api/ratings/reviews/${dup._id}`).expect(404);
+
+    // The authenticated rate write is refused too, and nothing is persisted.
+    await request(app)
+      .post('/api/ratings')
+      .set('Cookie', authCookie)
+      .send({ bookId: String(dup._id), rating: 5 })
+      .expect(404);
+    expect(await Rating.countDocuments({ bookId: dup._id })).toBe(0);
+
+    // Restoring the book brings summary, reviews and rate writes back.
+    await request(app)
+      .post('/api/duplicate-audit/unmark')
+      .set('Cookie', cookie)
+      .send({ duplicateIds: [String(dup._id)] })
+      .expect(200);
+
+    await request(app).get(`/api/ratings/summary/${dup._id}`).expect(200);
+    await request(app).get(`/api/ratings/reviews/${dup._id}`).expect(200);
+
+    const rate = await request(app)
+      .post('/api/ratings')
+      .set('Cookie', authCookie)
+      .send({ bookId: String(dup._id), rating: 5 })
+      .expect(200);
+    expect(String(rate.body.data.bookId)).toBe(String(dup._id));
+
+    const summary = await request(app).get(`/api/ratings/summary/${dup._id}`).expect(200);
+    expect(summary.body.data.count).toBe(1);
+    expect(summary.body.data.avgRating).toBe(5);
+  });
+
+  it('keeps the canonical book fully ratable while a duplicate is hidden', async () => {
+    const canonical = await makeBook({ name: 'Canonical Book' });
+    const dup = await makeBook({ name: 'Hidden Duplicate' });
+    const cookie = await makeCookie(true);
+    const authCookie = await makeCookie();
+
+    await request(app)
+      .post('/api/duplicate-audit/mark')
+      .set('Cookie', cookie)
+      .send(markBody(String(canonical._id), [String(dup._id)]))
+      .expect(200);
+
+    await request(app).get(`/api/ratings/summary/${canonical._id}`).expect(200);
+    await request(app).get(`/api/ratings/reviews/${canonical._id}`).expect(200);
+
+    const rate = await request(app)
+      .post('/api/ratings')
+      .set('Cookie', authCookie)
+      .send({ bookId: String(canonical._id), rating: 4 })
+      .expect(200);
+    expect(String(rate.body.data.bookId)).toBe(String(canonical._id));
+  });
+
+  it('returns 404 for ratings of a book id that does not exist', async () => {
+    const missing = String((await makeBook())._id);
+    await Books.findByIdAndRemove(missing);
+
+    await request(app).get(`/api/ratings/summary/${missing}`).expect(404);
+    await request(app).get(`/api/ratings/reviews/${missing}`).expect(404);
+
+    const authCookie = await makeCookie();
+    await request(app)
+      .post('/api/ratings')
+      .set('Cookie', authCookie)
+      .send({ bookId: missing, rating: 5 })
+      .expect(404);
+  });
+});

--- a/backend/routes/api/duplicateAudit.ts
+++ b/backend/routes/api/duplicateAudit.ts
@@ -1,11 +1,54 @@
 import express from 'express';
-import { getDuplicateAuditController } from '../../controllers/duplicateAudit.controller';
+import { body } from 'express-validator';
+import {
+  getDuplicateAuditController,
+  markDuplicateController,
+  unmarkDuplicateController,
+} from '../../controllers/duplicateAudit.controller';
 import { isAdmin } from '../../middleware/auth';
+import { validateRequest } from '../../middleware/validate-request';
 
 const router = express.Router();
 
 // GET /api/duplicate-audit?type=url&page=1&limit=20
 // Protected: Admin only, read-only duplicate audit over Books.
 router.get('/', isAdmin, getDuplicateAuditController);
+
+// POST /api/duplicate-audit/mark
+// Protected: Admin only. Soft-hides the given duplicate book ids under the
+// canonical book id. Deeper business rules (ObjectId format, max 50, existence,
+// self-mark, chain/cycle prevention) live in the mark service.
+router.post(
+  '/mark',
+  isAdmin,
+  [
+    body('canonicalId').isString().trim().notEmpty().withMessage('canonicalId is required'),
+    body('duplicateIds').isArray({ min: 1 }).withMessage('duplicateIds must be a non-empty array'),
+    body('duplicateIds.*')
+      .isString()
+      .trim()
+      .notEmpty()
+      .withMessage('Each duplicate book id must be a non-empty string'),
+  ],
+  validateRequest,
+  markDuplicateController
+);
+
+// POST /api/duplicate-audit/unmark
+// Protected: Admin only. Restores the given book ids to public visibility.
+router.post(
+  '/unmark',
+  isAdmin,
+  [
+    body('duplicateIds').isArray({ min: 1 }).withMessage('duplicateIds must be a non-empty array'),
+    body('duplicateIds.*')
+      .isString()
+      .trim()
+      .notEmpty()
+      .withMessage('Each duplicate book id must be a non-empty string'),
+  ],
+  validateRequest,
+  unmarkDuplicateController
+);
 
 export { router as duplicateAuditRouter };

--- a/backend/services/book/deleteBook.service.ts
+++ b/backend/services/book/deleteBook.service.ts
@@ -1,10 +1,20 @@
 // deleteBook.service.ts
-import { Request } from 'express';
-import { Books } from '../../models/Books';
+import type { Request } from 'express';
+import { BadRequestError } from '../../errors/bad-request-error';
 import { NotFoundError } from '../../errors/not-found-error';
+import { Books } from '../../models/Books';
 
 const deleteBook = async (req: Request) => {
   const id = req.params.id;
+  // A book that is the canonical of soft-hidden duplicates must not be
+  // deleted, otherwise the duplicates would point at a missing canonical.
+  const hiddenDuplicateExists = await Books.exists({ duplicateOf: id });
+  if (hiddenDuplicateExists) {
+    throw new BadRequestError(
+      'Cannot delete a book that is the canonical of hidden duplicates; unmark them first'
+    );
+  }
+
   const book = await Books.findByIdAndRemove(id);
 
   if (!book) {

--- a/backend/services/book/getAllBooks.service.ts
+++ b/backend/services/book/getAllBooks.service.ts
@@ -22,6 +22,8 @@ const getAllBooksService = async (req: Request) => {
     const startIndex = (page - 1) * limit;
 
     const query: Record<string, unknown> = {};
+    // Soft-hidden duplicates are invisible in the public all-books listing.
+    query.duplicateOf = null;
     if (language !== 'all') {
       query.language = language;
     }

--- a/backend/services/book/getBookById.service.ts
+++ b/backend/services/book/getBookById.service.ts
@@ -5,7 +5,11 @@ import type { PublicUploader } from '../../routes/api/books.types';
 
 const getBookById = async (req: Request) => {
   const id = req.params.id;
-  const book = await Books.findById(id).populate<{ uploader: PublicUploader | null }>({
+  // Soft-hidden duplicates are invisible via public detail: a marked book is
+  // treated as not found (the client renders its existing not-found state).
+  const book = await Books.findOne({ _id: id, duplicateOf: null }).populate<{
+    uploader: PublicUploader | null;
+  }>({
     path: 'uploader',
     select: '_id username',
   });

--- a/backend/services/book/recentlyAddedBooks.service.ts
+++ b/backend/services/book/recentlyAddedBooks.service.ts
@@ -24,11 +24,14 @@ const getRecentlyAddedBooks = async (params: PaginationParams = {}) => {
   const skip = (page - 1) * limit;
 
   try {
+    // Soft-hidden duplicates are invisible in the public recent listing.
+    const publicQuery = { duplicateOf: null };
+
     // Get total count for pagination metadata
-    const totalBooks = await Books.countDocuments({});
+    const totalBooks = await Books.countDocuments(publicQuery);
 
     // Get paginated books
-    const books = (await Books.find({})
+    const books = (await Books.find(publicQuery)
       .sort({ date: -1, createdAt: -1 }) // Sort by date first, then createdAt
       .skip(skip)
       .limit(limit)

--- a/backend/services/book/searchBooks.service.ts
+++ b/backend/services/book/searchBooks.service.ts
@@ -139,6 +139,9 @@ const searchBooksService = async (req: Request) => {
   const query: Record<string, unknown> =
     filters.length === 0 ? {} : filters.length === 1 ? filters[0] : { $and: filters };
 
+  // Soft-hidden duplicates never surface in public search.
+  query.duplicateOf = null;
+
   const page = parseBoundedPositiveInt(req.query.page, 1, MAX_PAGE);
   const limit = parseBoundedPositiveInt(req.query.limit, 10, MAX_LIMIT);
   const startIndex = (page - 1) * limit;
@@ -187,6 +190,14 @@ const searchBooksService = async (req: Request) => {
   cache.set(cacheKey, pagination); // store the result in the cache
 
   return pagination;
+};
+
+/**
+ * Narrow invalidator for the public search cache. Called by admin mark/unmark
+ * operations so cached search results never keep soft-hidden duplicates around.
+ */
+export const invalidateSearchCache = (): void => {
+  cache.flushAll();
 };
 
 export { searchBooksService };

--- a/backend/services/duplicateAudit/duplicateAudit.service.ts
+++ b/backend/services/duplicateAudit/duplicateAudit.service.ts
@@ -14,6 +14,8 @@ export interface DuplicateAuditBookItem {
   author: string | null;
   isbn: string | null;
   language: string;
+  /** Canonical book id when this book is already soft-hidden as a duplicate. */
+  duplicateOf: string | null;
 }
 
 export interface DuplicateAuditGroup {
@@ -64,6 +66,7 @@ interface ScannedBook {
   isbn?: string | null;
   author?: string | null;
   language?: string;
+  duplicateOf?: unknown;
 }
 
 const normalizeUrl = (value: string): string | null => {
@@ -134,6 +137,7 @@ const toBookItem = (book: ScannedBook): DuplicateAuditBookItem => ({
   author: typeof book.author === 'string' ? book.author : null,
   isbn: typeof book.isbn === 'string' ? book.isbn : null,
   language: typeof book.language === 'string' ? book.language : 'turkish',
+  duplicateOf: book.duplicateOf ? String(book.duplicateOf) : null,
 });
 
 const computeKeys = (book: ScannedBook): Record<DuplicateAuditType, string | null> => {
@@ -212,7 +216,7 @@ export const runDuplicateAuditService = async (
   const startedAt = Date.now();
 
   const scanned = (await Books.find()
-    .select('_id name size url isbn author language')
+    .select('_id name size url isbn author language duplicateOf')
     .limit(SCAN_LIMIT)
     .lean()) as unknown as ScannedBook[];
   const scannedBooks = scanned.length;

--- a/backend/services/duplicateAudit/duplicateMark.service.ts
+++ b/backend/services/duplicateAudit/duplicateMark.service.ts
@@ -1,0 +1,196 @@
+// duplicateMark.service.ts
+import mongoose from 'mongoose';
+import { BadRequestError } from '../../errors/bad-request-error';
+import { NotFoundError } from '../../errors/not-found-error';
+import { Books } from '../../models/Books';
+import { invalidateSearchCache } from '../book/searchBooks.service';
+
+export const MAX_DUPLICATE_BATCH = 50;
+
+export interface MarkDuplicateInput {
+  canonicalId: unknown;
+  duplicateIds: unknown;
+}
+
+export interface UnmarkDuplicateInput {
+  duplicateIds: unknown;
+}
+
+export interface MarkDuplicateResult {
+  canonicalId: string;
+  duplicateIds: string[];
+  updatedCount: number;
+}
+
+export interface UnmarkDuplicateResult {
+  duplicateIds: string[];
+  updatedCount: number;
+}
+
+const parseCanonicalId = (value: unknown): string => {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new BadRequestError('Canonical book id is required');
+  }
+  const id = value.trim();
+  if (!mongoose.isValidObjectId(id)) {
+    throw new BadRequestError('Invalid canonical book id');
+  }
+  return id;
+};
+
+const parseDuplicateIds = (value: unknown): string[] => {
+  if (!Array.isArray(value)) {
+    throw new BadRequestError('duplicateIds must be an array');
+  }
+  if (value.length === 0) {
+    throw new BadRequestError('At least one duplicate book id is required');
+  }
+  if (value.length > MAX_DUPLICATE_BATCH) {
+    throw new BadRequestError(`At most ${MAX_DUPLICATE_BATCH} duplicates can be updated at once`);
+  }
+
+  const ids: string[] = [];
+  for (const entry of value) {
+    if (typeof entry !== 'string' || !entry.trim()) {
+      throw new BadRequestError('Each duplicate book id must be a non-empty string');
+    }
+    const id = entry.trim();
+    if (!mongoose.isValidObjectId(id)) {
+      throw new BadRequestError('Invalid duplicate book id');
+    }
+    if (!ids.includes(id)) {
+      ids.push(id);
+    }
+  }
+  return ids;
+};
+
+const ensureBooksExist = async (ids: string[]): Promise<void> => {
+  const found = await Books.find({ _id: { $in: ids } })
+    .select('_id')
+    .lean();
+  if (found.length !== ids.length) {
+    throw new NotFoundError('One or more books were not found');
+  }
+};
+
+/**
+ * In-process serialization for the admin mark/unmark mutations. There is no
+ * unique duplicateOf index (per the operator-approved minimal plan), so the
+ * validate-then-write flow could otherwise race: two concurrent requests could
+ * both pass the existence/chain/repoint checks and then repoint the same book.
+ * A single module-level promise queue runs these admin operations one at a
+ * time, keeping validation inside the queued function.
+ */
+let mutationQueue: Promise<unknown> = Promise.resolve();
+
+const runExclusive = <T>(operation: () => Promise<T>): Promise<T> => {
+  const run = mutationQueue.then(operation, operation);
+  // Keep the queue alive even when a queued operation rejects.
+  mutationQueue = run.then(
+    () => undefined,
+    () => undefined
+  );
+  return run;
+};
+
+const markDuplicateQueued = async (input: MarkDuplicateInput): Promise<MarkDuplicateResult> => {
+  const canonicalId = parseCanonicalId(input.canonicalId);
+  const duplicateIds = parseDuplicateIds(input.duplicateIds);
+
+  if (duplicateIds.includes(canonicalId)) {
+    throw new BadRequestError('A book cannot be marked as its own duplicate');
+  }
+
+  const requestedIds = [canonicalId, ...duplicateIds];
+  const books = await Books.find({ _id: { $in: requestedIds } })
+    .select('_id duplicateOf')
+    .lean();
+  if (books.length !== requestedIds.length) {
+    throw new NotFoundError('One or more books were not found');
+  }
+
+  const canonical = books.find((book) => String(book._id) === canonicalId);
+  if (canonical?.duplicateOf) {
+    throw new BadRequestError('The canonical book is already hidden as a duplicate');
+  }
+
+  // Chain guard: none of the selected duplicates may currently be the
+  // canonical of another book, otherwise hiding them would strand a chain of
+  // hidden books beneath another hidden book.
+  const referenced = await Books.find({ duplicateOf: { $in: duplicateIds } })
+    .select('_id')
+    .limit(1)
+    .lean();
+  if (referenced.length > 0) {
+    throw new BadRequestError(
+      'A selected duplicate is already the canonical of another book; unmark those first'
+    );
+  }
+
+  // A duplicate already hidden under a different canonical must not be
+  // silently repointed; require an explicit unmark first.
+  const duplicateDocs = books.filter((book) => duplicateIds.includes(String(book._id)));
+  const repointCandidate = duplicateDocs.find(
+    (book) => book.duplicateOf && String(book.duplicateOf) !== canonicalId
+  );
+  if (repointCandidate) {
+    throw new BadRequestError(
+      'One or more selected duplicates are already hidden under another canonical; unmark them first'
+    );
+  }
+
+  // Books already hidden under this same canonical make the call idempotent;
+  // only the still-public books are eligible for this pass.
+  const pendingIds = duplicateDocs
+    .filter((book) => !book.duplicateOf)
+    .map((book) => String(book._id));
+
+  if (pendingIds.length === 0) {
+    return { canonicalId, duplicateIds, updatedCount: 0 };
+  }
+
+  const result = await Books.updateMany(
+    { _id: { $in: pendingIds }, duplicateOf: null },
+    { $set: { duplicateOf: canonicalId } }
+  );
+
+  // The write must have hit every eligible book. A shortfall means a selected
+  // book was hidden between the read and the write; fail loudly instead of
+  // silently leaving it under the wrong canonical.
+  if (result.modifiedCount !== pendingIds.length) {
+    throw new BadRequestError(
+      'One or more selected duplicates were hidden concurrently; refresh and try again'
+    );
+  }
+
+  invalidateSearchCache();
+
+  return { canonicalId, duplicateIds, updatedCount: result.modifiedCount };
+};
+
+const unmarkDuplicateQueued = async (
+  input: UnmarkDuplicateInput
+): Promise<UnmarkDuplicateResult> => {
+  const duplicateIds = parseDuplicateIds(input.duplicateIds);
+
+  await ensureBooksExist(duplicateIds);
+
+  const result = await Books.updateMany(
+    { _id: { $in: duplicateIds } },
+    { $set: { duplicateOf: null } }
+  );
+
+  if (result.modifiedCount > 0) {
+    invalidateSearchCache();
+  }
+
+  return { duplicateIds, updatedCount: result.modifiedCount };
+};
+
+export const markDuplicateService = (input: MarkDuplicateInput): Promise<MarkDuplicateResult> =>
+  runExclusive(() => markDuplicateQueued(input));
+
+export const unmarkDuplicateService = (
+  input: UnmarkDuplicateInput
+): Promise<UnmarkDuplicateResult> => runExclusive(() => unmarkDuplicateQueued(input));

--- a/client/src/pages/AdminDuplicateAudit.tsx
+++ b/client/src/pages/AdminDuplicateAudit.tsx
@@ -1,7 +1,16 @@
-import { AlertTriangle, ChevronLeft, ChevronRight, Download, Play, Search } from 'lucide-react';
-import { useState } from 'react';
+import {
+  AlertTriangle,
+  ChevronLeft,
+  ChevronRight,
+  Download,
+  Play,
+  Search,
+  Undo2,
+} from 'lucide-react';
+import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { Navigate } from 'react-router-dom';
+import { toast } from 'sonner';
 import Layout from '@/components/Layout';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
@@ -27,6 +36,8 @@ import {
   type DuplicateAuditResult,
   type DuplicateAuditType,
   useLazyGetDuplicateAuditQuery,
+  useMarkDuplicateMutation,
+  useUnmarkDuplicateMutation,
 } from '@/redux/services/duplicateAudit.api';
 import type { RootState } from '@/redux/store';
 
@@ -104,17 +115,47 @@ const downloadBlob = (blob: Blob, filename: string) => {
   URL.revokeObjectURL(url);
 };
 
+/** Pull the first backend error message out of an RTK Query rejection. */
+const getErrorMessage = (error: unknown): string => {
+  const message = (error as { data?: { errors?: { message?: string }[] } })?.data?.errors?.[0]
+    ?.message;
+  return message || 'Something went wrong. Please try again.';
+};
+
 const AdminDuplicateAudit = () => {
   const [type, setType] = useState<DuplicateAuditType>('url');
+  const [page, setPage] = useState(1);
+  const [canonicalByGroup, setCanonicalByGroup] = useState<Record<string, string>>({});
+  const [selectedDuplicates, setSelectedDuplicates] = useState<Record<string, string[]>>({});
 
   const { user, isLoggedIn } = useSelector((state: RootState) => state.authSlice);
   const isAdmin = isLoggedIn && user.user.isAdmin;
 
   const [trigger, { data, isFetching, isError, error }] = useLazyGetDuplicateAuditQuery();
+  const [markDuplicate, { isLoading: isMarking }] = useMarkDuplicateMutation();
+  const [unmarkDuplicate, { isLoading: isUnmarking }] = useUnmarkDuplicateMutation();
+
+  const isMutating = isMarking || isUnmarking;
 
   const totalPages = data ? Math.max(1, Math.ceil(data.totalGroups / data.limit)) : 1;
-  const errorMessage = (error as { data?: { errors?: { message?: string }[] } })?.data?.errors?.[0]
-    ?.message;
+  const errorMessage = getErrorMessage(error);
+
+  // Reset per-group selections whenever a new report arrives (initial run,
+  // type/page change or the refetch that follows a mark/unmark mutation).
+  // Kept above the admin early return so hook order is unconditional.
+  useEffect(() => {
+    if (!data) return;
+    const nextCanonicals: Record<string, string> = {};
+    const nextSelections: Record<string, string[]> = {};
+    for (const group of data.groups) {
+      // Sensible default canonical: the first unmarked book in the group.
+      const unmarked = group.books.filter((book) => !book.duplicateOf);
+      nextCanonicals[group.key] = (unmarked[0] ?? group.books[0])?.bookId ?? '';
+      nextSelections[group.key] = [];
+    }
+    setCanonicalByGroup(nextCanonicals);
+    setSelectedDuplicates(nextSelections);
+  }, [data]);
 
   // Redirect non-admin users
   if (!isAdmin) {
@@ -123,11 +164,66 @@ const AdminDuplicateAudit = () => {
 
   const runAudit = (nextType = type, nextPage = 1) => {
     setType(nextType);
+    setPage(nextPage);
     void trigger({ type: nextType, page: nextPage, limit: PAGE_SIZE });
   };
 
   const handlePageChange = (nextPage: number) => {
+    setPage(nextPage);
     void trigger({ type, page: nextPage, limit: PAGE_SIZE });
+  };
+
+  const rerunCurrentAudit = () => {
+    void trigger({ type, page, limit: PAGE_SIZE });
+  };
+
+  const handleCanonicalChange = (groupKey: string, bookId: string) => {
+    setCanonicalByGroup((prev) => ({ ...prev, [groupKey]: bookId }));
+    // A book promoted to canonical can no longer be a selected duplicate.
+    setSelectedDuplicates((prev) => ({
+      ...prev,
+      [groupKey]: (prev[groupKey] ?? []).filter((id) => id !== bookId),
+    }));
+  };
+
+  const handleDuplicateToggle = (groupKey: string, bookId: string) => {
+    setSelectedDuplicates((prev) => {
+      const current = prev[groupKey] ?? [];
+      const next = current.includes(bookId)
+        ? current.filter((id) => id !== bookId)
+        : [...current, bookId];
+      return { ...prev, [groupKey]: next };
+    });
+  };
+
+  const handleMark = async (groupKey: string) => {
+    const canonicalId = canonicalByGroup[groupKey];
+    const duplicateIds = selectedDuplicates[groupKey] ?? [];
+    if (!canonicalId || duplicateIds.length === 0 || isMutating) return;
+
+    const confirmed = window.confirm(
+      `Mark ${duplicateIds.length} book${duplicateIds.length === 1 ? '' : 's'} as duplicates of ${canonicalId}? They will be hidden from the public site.`
+    );
+    if (!confirmed) return;
+
+    try {
+      const result = await markDuplicate({ canonicalId, duplicateIds }).unwrap();
+      toast.success(`Marked ${result.updatedCount} book(s) as duplicates`);
+      rerunCurrentAudit();
+    } catch (err) {
+      toast.error(getErrorMessage(err));
+    }
+  };
+
+  const handleUndo = async (bookId: string) => {
+    if (isMutating) return;
+    try {
+      const result = await unmarkDuplicate({ duplicateIds: [bookId] }).unwrap();
+      toast.success(`Restored ${result.updatedCount} book(s)`);
+      rerunCurrentAudit();
+    } catch (err) {
+      toast.error(getErrorMessage(err));
+    }
   };
 
   const downloadJson = () => {
@@ -170,7 +266,7 @@ const AdminDuplicateAudit = () => {
               </Select>
             </div>
 
-            <Button onClick={() => runAudit(type)} disabled={isFetching}>
+            <Button onClick={() => runAudit(type)} disabled={isFetching || isMutating}>
               {isFetching ? <LoadingSpinner size={16} /> : <Play className="h-4 w-4" />}
               {isFetching ? 'Running…' : 'Run Audit'}
             </Button>
@@ -233,44 +329,121 @@ const AdminDuplicateAudit = () => {
                 </p>
               </Card>
             ) : (
-              <Card>
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>Group Key</TableHead>
-                      <TableHead>Reason</TableHead>
-                      <TableHead>Confidence</TableHead>
-                      <TableHead>Book ID</TableHead>
-                      <TableHead>Name</TableHead>
-                      <TableHead>Author</TableHead>
-                      <TableHead>ISBN</TableHead>
-                      <TableHead>Language</TableHead>
-                      <TableHead className="text-right">Size</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {data.groups.flatMap((group) =>
-                      group.books.map((book) => (
-                        <TableRow key={`${group.key}-${book.bookId}`}>
-                          <TableCell className="font-mono text-xs">{group.key}</TableCell>
-                          <TableCell>{TYPE_LABELS[group.type]}</TableCell>
-                          <TableCell>
-                            <Badge variant={group.confidence === 'exact' ? 'success' : 'warning'}>
-                              {group.confidence}
-                            </Badge>
-                          </TableCell>
-                          <TableCell className="font-mono text-xs">{book.bookId}</TableCell>
-                          <TableCell>{book.name}</TableCell>
-                          <TableCell>{book.author ?? '—'}</TableCell>
-                          <TableCell>{book.isbn ?? '—'}</TableCell>
-                          <TableCell>{book.language}</TableCell>
-                          <TableCell className="text-right">{book.size ?? '—'}</TableCell>
-                        </TableRow>
-                      ))
-                    )}
-                  </TableBody>
-                </Table>
-              </Card>
+              <div className="space-y-6">
+                {data.groups.map((group) => {
+                  const canonicalId = canonicalByGroup[group.key] ?? '';
+                  const selected = selectedDuplicates[group.key] ?? [];
+                  return (
+                    <Card key={group.key} data-testid={`group-${group.key}`}>
+                      <div className="flex flex-wrap items-center gap-3 p-4 border-b">
+                        <span className="font-mono text-xs">{group.key}</span>
+                        <Badge variant={group.confidence === 'exact' ? 'success' : 'warning'}>
+                          {group.confidence}
+                        </Badge>
+                        <span className="text-sm text-muted-foreground">
+                          {TYPE_LABELS[group.type]}
+                        </span>
+                        <span className="text-sm text-muted-foreground">
+                          {group.count} {group.count === 1 ? 'book' : 'books'}
+                        </span>
+                      </div>
+
+                      <Table>
+                        <TableHeader>
+                          <TableRow>
+                            <TableHead>Canonical</TableHead>
+                            <TableHead>Duplicate</TableHead>
+                            <TableHead>Book ID</TableHead>
+                            <TableHead>Name</TableHead>
+                            <TableHead>Author</TableHead>
+                            <TableHead>ISBN</TableHead>
+                            <TableHead>Language</TableHead>
+                            <TableHead className="text-right">Size</TableHead>
+                            <TableHead>Status</TableHead>
+                          </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                          {group.books.map((book) => {
+                            const isMarked = Boolean(book.duplicateOf);
+                            const isCanonical = canonicalId === book.bookId;
+                            return (
+                              <TableRow key={`${group.key}-${book.bookId}`}>
+                                <TableCell>
+                                  <input
+                                    type="radio"
+                                    name={`canonical-${group.key}`}
+                                    value={book.bookId}
+                                    checked={isCanonical}
+                                    onChange={() => handleCanonicalChange(group.key, book.bookId)}
+                                    disabled={isMutating || isMarked}
+                                    aria-label={`Set ${book.name} as canonical`}
+                                  />
+                                </TableCell>
+                                <TableCell>
+                                  <input
+                                    type="checkbox"
+                                    checked={selected.includes(book.bookId)}
+                                    onChange={() => handleDuplicateToggle(group.key, book.bookId)}
+                                    disabled={isMutating || isMarked || isCanonical}
+                                    aria-label={`Select ${book.name} as duplicate`}
+                                  />
+                                </TableCell>
+                                <TableCell className="font-mono text-xs">{book.bookId}</TableCell>
+                                <TableCell>{book.name}</TableCell>
+                                <TableCell>{book.author ?? '—'}</TableCell>
+                                <TableCell>{book.isbn ?? '—'}</TableCell>
+                                <TableCell>{book.language}</TableCell>
+                                <TableCell className="text-right">{book.size ?? '—'}</TableCell>
+                                <TableCell>
+                                  {isMarked && book.duplicateOf ? (
+                                    <div className="flex items-center gap-2">
+                                      <Badge
+                                        variant="warning"
+                                        data-testid={`marked-${book.bookId}`}
+                                      >
+                                        Duplicate of {book.duplicateOf}
+                                      </Badge>
+                                      <Button
+                                        variant="outline"
+                                        size="sm"
+                                        onClick={() => handleUndo(book.bookId)}
+                                        disabled={isMutating}
+                                        aria-label={`Undo mark for ${book.name}`}
+                                      >
+                                        <Undo2 className="h-3.5 w-3.5" />
+                                        Undo
+                                      </Button>
+                                    </div>
+                                  ) : (
+                                    <span className="text-sm text-muted-foreground">—</span>
+                                  )}
+                                </TableCell>
+                              </TableRow>
+                            );
+                          })}
+                        </TableBody>
+                      </Table>
+
+                      <div className="flex flex-wrap items-center justify-between gap-3 p-4 border-t">
+                        <p
+                          className="text-sm text-muted-foreground"
+                          data-testid={`selection-count-${group.key}`}
+                        >
+                          {selected.length}{' '}
+                          {selected.length === 1 ? 'duplicate selected' : 'duplicates selected'}
+                        </p>
+                        <Button
+                          onClick={() => handleMark(group.key)}
+                          disabled={isMutating || selected.length === 0 || !canonicalId}
+                        >
+                          {isMarking ? <LoadingSpinner size={16} /> : <Play className="h-4 w-4" />}
+                          Mark duplicates
+                        </Button>
+                      </div>
+                    </Card>
+                  );
+                })}
+              </div>
             )}
 
             <div className="flex flex-wrap items-center justify-between gap-4 mt-6">

--- a/client/src/pages/__tests__/AdminDuplicateAudit.test.tsx
+++ b/client/src/pages/__tests__/AdminDuplicateAudit.test.tsx
@@ -1,5 +1,5 @@
 import { configureStore } from '@reduxjs/toolkit';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { type ReactNode, useState } from 'react';
 import { Provider } from 'react-redux';
@@ -10,7 +10,7 @@ import authReducer, { loadUser } from '@/redux/authSlice';
 import { commonApi } from '@/redux/common.api';
 import type { DuplicateAuditResult } from '@/redux/services/duplicateAudit.api';
 
-// Partial-mock the audit API only: the hook is stubbed while the real
+// Partial-mock the audit API only: the hooks are stubbed while the real
 // commonApi reducer and middleware stay in the test store.
 const apiMocks = vi.hoisted(() => {
   const state: {
@@ -20,18 +20,43 @@ const apiMocks = vi.hoisted(() => {
     error: unknown;
   } = { data: null, isFetching: false, isError: false, error: undefined };
 
+  // The page only reads isLoading from the mutation hooks, so the stateful
+  // stubs track just that flag.
+  const markState: { isLoading: boolean } = { isLoading: false };
+
+  const unmarkState: { isLoading: boolean } = { isLoading: false };
+
+  // Optional rejection payload for the unmark mutation.
+  const unmarkError: { error: unknown } = { error: undefined };
+
   return {
     trigger: vi.fn(),
+    markFn: vi.fn(),
+    unmarkFn: vi.fn(),
     state,
+    markState,
+    unmarkState,
+    unmarkError,
     reset() {
       state.data = null;
       state.isFetching = false;
       state.isError = false;
       state.error = undefined;
+      markState.isLoading = false;
+      unmarkState.isLoading = false;
+      unmarkError.error = undefined;
       apiMocks.trigger.mockClear();
+      apiMocks.markFn.mockClear();
+      apiMocks.unmarkFn.mockClear();
     },
   };
 });
+
+const toastMocks = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }));
+
+vi.mock('sonner', () => ({
+  toast: { success: toastMocks.success, error: toastMocks.error },
+}));
 
 vi.mock('@/redux/services/duplicateAudit.api', () => ({
   // Stateful stub: trigger records its args and snapshots apiMocks.state so a
@@ -44,6 +69,29 @@ vi.mock('@/redux/services/duplicateAudit.api', () => ({
       setResult({ ...apiMocks.state });
     };
     return [trigger, result];
+  },
+  // Mutation stubs: record their payload and resolve/reject based on the
+  // configured outcome, mirroring the shape of an RTK Query mutation hook.
+  useMarkDuplicateMutation: () => {
+    const [result] = useState({ ...apiMocks.markState });
+    const run = (args: unknown) => {
+      apiMocks.markFn(args);
+      return {
+        unwrap: () => Promise.resolve({ canonicalId: 'b1', duplicateIds: ['b2'], updatedCount: 1 }),
+      };
+    };
+    return [run, result];
+  },
+  useUnmarkDuplicateMutation: () => {
+    const [result] = useState({ ...apiMocks.unmarkState });
+    const run = (args: unknown) => {
+      apiMocks.unmarkFn(args);
+      if (apiMocks.unmarkError.error !== undefined) {
+        return { unwrap: () => Promise.reject(apiMocks.unmarkError.error) };
+      }
+      return { unwrap: () => Promise.resolve({ duplicateIds: ['b2'], updatedCount: 1 }) };
+    };
+    return [run, result];
   },
 }));
 
@@ -94,6 +142,7 @@ const report: DuplicateAuditResult = {
           author: null,
           isbn: null,
           language: 'turkish',
+          duplicateOf: null,
         },
         {
           bookId: 'b2',
@@ -102,6 +151,7 @@ const report: DuplicateAuditResult = {
           author: '=SUM(A1)',
           isbn: '9780000000000',
           language: 'turkish',
+          duplicateOf: null,
         },
       ],
     },
@@ -113,6 +163,20 @@ const report: DuplicateAuditResult = {
   totalBooks: 3,
   isTruncated: false,
   durationMs: 5,
+};
+
+// Post-mark state: b2 is now soft-hidden as a duplicate of b1.
+const markedReport: DuplicateAuditResult = {
+  ...report,
+  groups: [
+    {
+      ...report.groups[0],
+      books: [
+        { ...report.groups[0].books[0], duplicateOf: null },
+        { ...report.groups[0].books[1], duplicateOf: 'b1' },
+      ],
+    },
+  ],
 };
 
 const pagedReport: DuplicateAuditResult = { ...report, totalGroups: 45 };
@@ -158,6 +222,8 @@ function renderAudit(isAdmin = true) {
 describe('AdminDuplicateAudit', () => {
   beforeEach(() => {
     apiMocks.reset();
+    toastMocks.success.mockClear();
+    toastMocks.error.mockClear();
   });
 
   afterEach(() => {
@@ -202,15 +268,160 @@ describe('AdminDuplicateAudit', () => {
     expect(screen.getByTestId('summary-total-groups')).toHaveTextContent('1');
     expect(screen.queryByTestId('truncated-warning')).not.toBeInTheDocument();
 
-    // The group key and the confidence badge repeat once per book row inside
-    // the group, so scope the queries to the table and use plural getters for
-    // those duplicated values.
-    const table = screen.getByRole('table');
-    expect(within(table).getAllByText('a1b2c3d4e5f60718')).toHaveLength(2);
-    expect(within(table).getByText('Alpha')).toBeInTheDocument();
-    expect(within(table).getByText('Küçük Prens, "Ciltli"')).toBeInTheDocument();
-    expect(within(table).getAllByText('exact', { exact: true })).toHaveLength(2);
-    expect(within(table).getByRole('columnheader', { name: 'Group Key' })).toBeInTheDocument();
+    // Each group is its own card with a canonical/duplicate selection row and
+    // a status cell; the group key and confidence live in the card header.
+    const group = screen.getByTestId('group-a1b2c3d4e5f60718');
+    expect(within(group).getByText('a1b2c3d4e5f60718')).toBeInTheDocument();
+    expect(within(group).getByText('exact', { exact: true })).toBeInTheDocument();
+    expect(within(group).getByText('Alpha')).toBeInTheDocument();
+    expect(within(group).getByText('Küçük Prens, "Ciltli"')).toBeInTheDocument();
+
+    const table = within(group).getByRole('table');
+    expect(within(table).getByRole('columnheader', { name: 'Canonical' })).toBeInTheDocument();
+    expect(within(table).getByRole('columnheader', { name: 'Duplicate' })).toBeInTheDocument();
+  });
+
+  it('defaults the canonical to the first unmarked book and supports switching', async () => {
+    const user = userEvent.setup();
+    apiMocks.state.data = report;
+    renderAudit();
+
+    await user.click(screen.getByRole('button', { name: 'Run Audit' }));
+
+    const alphaRadio = screen.getByRole('radio', { name: 'Set Alpha as canonical' });
+    const prensRadio = screen.getByRole('radio', {
+      name: 'Set Küçük Prens, "Ciltli" as canonical',
+    });
+    expect(alphaRadio).toBeChecked();
+    expect(prensRadio).not.toBeChecked();
+
+    // The canonical book cannot also be selected as a duplicate.
+    expect(screen.getByRole('checkbox', { name: 'Select Alpha as duplicate' })).toBeDisabled();
+    expect(
+      screen.getByRole('checkbox', { name: 'Select Küçük Prens, "Ciltli" as duplicate' })
+    ).toBeEnabled();
+
+    await user.click(prensRadio);
+
+    expect(prensRadio).toBeChecked();
+    expect(alphaRadio).not.toBeChecked();
+    // Alpha can now be selected as a duplicate instead.
+    expect(screen.getByRole('checkbox', { name: 'Select Alpha as duplicate' })).toBeEnabled();
+    expect(
+      screen.getByRole('checkbox', { name: 'Select Küçük Prens, "Ciltli" as duplicate' })
+    ).toBeDisabled();
+  });
+
+  it('sends the canonical and selected duplicates to the mark mutation after confirmation', async () => {
+    const user = userEvent.setup();
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    apiMocks.state.data = report;
+    renderAudit();
+
+    await user.click(screen.getByRole('button', { name: 'Run Audit' }));
+    await user.click(
+      screen.getByRole('checkbox', { name: 'Select Küçük Prens, "Ciltli" as duplicate' })
+    );
+    await user.click(screen.getByRole('button', { name: 'Mark duplicates' }));
+
+    expect(apiMocks.markFn).toHaveBeenCalledTimes(1);
+    expect(apiMocks.markFn).toHaveBeenCalledWith({ canonicalId: 'b1', duplicateIds: ['b2'] });
+    expect(toastMocks.success).toHaveBeenCalledWith('Marked 1 book(s) as duplicates');
+
+    // The current audit re-runs after a successful mutation.
+    expect(apiMocks.trigger).toHaveBeenCalledTimes(2);
+    expect(apiMocks.trigger).toHaveBeenLastCalledWith({ type: 'url', page: 1, limit: 20 });
+  });
+
+  it('does not fire the mark mutation when the confirm dialog is cancelled', async () => {
+    const user = userEvent.setup();
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    apiMocks.state.data = report;
+    renderAudit();
+
+    await user.click(screen.getByRole('button', { name: 'Run Audit' }));
+    await user.click(
+      screen.getByRole('checkbox', { name: 'Select Küçük Prens, "Ciltli" as duplicate' })
+    );
+    await user.click(screen.getByRole('button', { name: 'Mark duplicates' }));
+
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(apiMocks.markFn).not.toHaveBeenCalled();
+    expect(apiMocks.trigger).toHaveBeenCalledTimes(1);
+    expect(toastMocks.success).not.toHaveBeenCalled();
+  });
+
+  it('shows a marked badge with the canonical id and undoes a single row', async () => {
+    const user = userEvent.setup();
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    apiMocks.state.data = report;
+    renderAudit();
+
+    await user.click(screen.getByRole('button', { name: 'Run Audit' }));
+    await user.click(
+      screen.getByRole('checkbox', { name: 'Select Küçük Prens, "Ciltli" as duplicate' })
+    );
+
+    // The server now returns the post-mark report; the rerun after the
+    // successful mutation picks it up and renders the marked badge.
+    apiMocks.state.data = markedReport;
+    await user.click(screen.getByRole('button', { name: 'Mark duplicates' }));
+
+    expect(apiMocks.markFn).toHaveBeenCalledWith({ canonicalId: 'b1', duplicateIds: ['b2'] });
+    const badge = screen.getByTestId('marked-b2');
+    expect(badge).toHaveTextContent('Duplicate of b1');
+
+    const undoButton = screen.getByRole('button', {
+      name: 'Undo mark for Küçük Prens, "Ciltli"',
+    });
+    expect(undoButton).toBeEnabled();
+
+    // Restore the unmarked report so the post-undo rerun clears the badge.
+    apiMocks.state.data = report;
+    await user.click(undoButton);
+
+    expect(apiMocks.unmarkFn).toHaveBeenCalledTimes(1);
+    expect(apiMocks.unmarkFn).toHaveBeenCalledWith({ duplicateIds: ['b2'] });
+    expect(toastMocks.success).toHaveBeenCalledWith('Restored 1 book(s)');
+    await waitFor(() => {
+      expect(screen.queryByTestId('marked-b2')).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows an error toast and skips the rerun when undo fails', async () => {
+    const user = userEvent.setup();
+    apiMocks.state.data = markedReport;
+    apiMocks.unmarkError.error = {
+      data: { errors: [{ message: 'Undo failed' }] },
+    };
+    renderAudit();
+
+    await user.click(screen.getByRole('button', { name: 'Run Audit' }));
+
+    expect(screen.getByTestId('marked-b2')).toHaveTextContent('Duplicate of b1');
+
+    apiMocks.trigger.mockClear();
+    await user.click(screen.getByRole('button', { name: 'Undo mark for Küçük Prens, "Ciltli"' }));
+
+    expect(apiMocks.unmarkFn).toHaveBeenCalledWith({ duplicateIds: ['b2'] });
+    expect(toastMocks.error).toHaveBeenCalledWith('Undo failed');
+    expect(apiMocks.trigger).not.toHaveBeenCalled();
+  });
+
+  it('disables all mark controls while a mark mutation is in flight', async () => {
+    apiMocks.markState.isLoading = true;
+    apiMocks.state.data = report;
+    renderAudit();
+
+    expect(screen.getByRole('button', { name: 'Run Audit' })).toBeDisabled();
+    expect(screen.getByRole('radio', { name: 'Set Alpha as canonical' })).toBeDisabled();
+    expect(
+      screen.getByRole('radio', { name: 'Set Küçük Prens, "Ciltli" as canonical' })
+    ).toBeDisabled();
+    expect(
+      screen.getByRole('checkbox', { name: 'Select Küçük Prens, "Ciltli" as duplicate' })
+    ).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Mark duplicates' })).toBeDisabled();
   });
 
   it('passes the next page when navigating pagination', async () => {
@@ -275,6 +486,7 @@ describe('AdminDuplicateAudit', () => {
       author: null,
       isbn: null,
       language: 'turkish',
+      duplicateOf: null,
     });
     expect(jsonText).not.toContain('uploader');
     expect(jsonText).not.toContain('email');

--- a/client/src/redux/common.api.ts
+++ b/client/src/redux/common.api.ts
@@ -65,6 +65,6 @@ export const createBaseQueryWithReauth =
 export const commonApi = createApi({
   reducerPath: 'api',
   baseQuery: createBaseQueryWithReauth(baseQuery),
-  tagTypes: ['Book', 'Messages'],
+  tagTypes: ['Book', 'Messages', 'Audit'],
   endpoints: (_) => ({}),
 });

--- a/client/src/redux/services/duplicateAudit.api.ts
+++ b/client/src/redux/services/duplicateAudit.api.ts
@@ -11,6 +11,8 @@ export interface DuplicateAuditBookItem {
   author: string | null;
   isbn: string | null;
   language: string;
+  /** Canonical book id when this book is already soft-hidden as a duplicate. */
+  duplicateOf: string | null;
 }
 
 export interface DuplicateAuditGroup {
@@ -42,6 +44,26 @@ export interface DuplicateAuditQueryArgs {
   limit?: number;
 }
 
+export interface MarkDuplicateArgs {
+  canonicalId: string;
+  duplicateIds: string[];
+}
+
+export interface MarkDuplicateResult {
+  canonicalId: string;
+  duplicateIds: string[];
+  updatedCount: number;
+}
+
+export interface UnmarkDuplicateArgs {
+  duplicateIds: string[];
+}
+
+export interface UnmarkDuplicateResult {
+  duplicateIds: string[];
+  updatedCount: number;
+}
+
 export const duplicateAuditApi = commonApi.injectEndpoints({
   endpoints: (build) => ({
     // GET /api/duplicate-audit?type=url&page=1&limit=20
@@ -51,8 +73,37 @@ export const duplicateAuditApi = commonApi.injectEndpoints({
         url: '/duplicate-audit',
         params: { type, page, limit },
       }),
+      providesTags: () => [{ type: 'Audit' }],
+    }),
+
+    // POST /api/duplicate-audit/mark
+    // Soft-hides the given duplicates under the canonical book. Any cached
+    // audit and public book listings are refreshed so hidden books disappear
+    // from the site immediately.
+    markDuplicate: build.mutation<MarkDuplicateResult, MarkDuplicateArgs>({
+      query: (body) => ({
+        url: '/duplicate-audit/mark',
+        method: 'POST',
+        body,
+      }),
+      invalidatesTags: [{ type: 'Audit' }, { type: 'Book' }],
+    }),
+
+    // POST /api/duplicate-audit/unmark
+    // Restores the given books to public visibility.
+    unmarkDuplicate: build.mutation<UnmarkDuplicateResult, UnmarkDuplicateArgs>({
+      query: (body) => ({
+        url: '/duplicate-audit/unmark',
+        method: 'POST',
+        body,
+      }),
+      invalidatesTags: [{ type: 'Audit' }, { type: 'Book' }],
     }),
   }),
 });
 
-export const { useLazyGetDuplicateAuditQuery } = duplicateAuditApi;
+export const {
+  useLazyGetDuplicateAuditQuery,
+  useMarkDuplicateMutation,
+  useUnmarkDuplicateMutation,
+} = duplicateAuditApi;

--- a/client/tests/duplicate-audit.spec.ts
+++ b/client/tests/duplicate-audit.spec.ts
@@ -18,6 +18,7 @@ const MOCK_AUDIT_REPORT = {
           author: null,
           isbn: null,
           language: 'turkish',
+          duplicateOf: null,
         },
         {
           bookId: 'b2',
@@ -26,6 +27,7 @@ const MOCK_AUDIT_REPORT = {
           author: '=SUM(A1)',
           isbn: '9780000000000',
           language: 'turkish',
+          duplicateOf: null,
         },
       ],
     },
@@ -41,12 +43,34 @@ const MOCK_AUDIT_REPORT = {
 
 test.describe('Duplicate audit', () => {
   let auditRequestCount = 0;
+  let markPayloads: Array<{ canonicalId: string; duplicateIds: string[] }> = [];
+  let unmarkPayloads: Array<{ duplicateIds: string[] }> = [];
+  // bookId -> canonicalId for books soft-hidden by the mock mark route.
+  const marked: Record<string, string> = {};
+
+  const currentReport = () => ({
+    ...MOCK_AUDIT_REPORT,
+    groups: MOCK_AUDIT_REPORT.groups.map((group) => ({
+      ...group,
+      books: group.books.map((book) => ({
+        ...book,
+        duplicateOf: marked[book.bookId] ?? null,
+      })),
+    })),
+  });
 
   test.beforeEach(async ({ page }) => {
     auditRequestCount = 0;
+    markPayloads = [];
+    unmarkPayloads = [];
+    for (const key of Object.keys(marked)) {
+      delete marked[key];
+    }
 
     // Register API mocks BEFORE the global external block so they take
-    // priority under Playwright's reverse registration order.
+    // priority under Playwright's reverse registration order. The generic
+    // audit route is registered before the mark/unmark routes, so the more
+    // specific mutation routes win for their paths.
     await page.route('**/api/user/auth', async (route) => {
       await route.fulfill({
         status: 200,
@@ -67,7 +91,43 @@ test.describe('Duplicate audit', () => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify(MOCK_AUDIT_REPORT),
+        body: JSON.stringify(currentReport()),
+      });
+    });
+
+    await page.route('**/api/duplicate-audit/mark', async (route) => {
+      const body = route.request().postDataJSON() as {
+        canonicalId: string;
+        duplicateIds: string[];
+      };
+      markPayloads.push(body);
+      for (const duplicateId of body.duplicateIds) {
+        marked[duplicateId] = body.canonicalId;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          canonicalId: body.canonicalId,
+          duplicateIds: body.duplicateIds,
+          updatedCount: body.duplicateIds.length,
+        }),
+      });
+    });
+
+    await page.route('**/api/duplicate-audit/unmark', async (route) => {
+      const body = route.request().postDataJSON() as { duplicateIds: string[] };
+      unmarkPayloads.push(body);
+      for (const duplicateId of body.duplicateIds) {
+        delete marked[duplicateId];
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          duplicateIds: body.duplicateIds,
+          updatedCount: body.duplicateIds.length,
+        }),
       });
     });
 
@@ -96,7 +156,8 @@ test.describe('Duplicate audit', () => {
 
     const table = page.getByRole('table');
     await expect(table).toBeVisible();
-    await expect(table.getByRole('columnheader', { name: 'Group Key' })).toBeVisible();
+    await expect(table.getByRole('columnheader', { name: 'Canonical' })).toBeVisible();
+    await expect(table.getByRole('columnheader', { name: 'Duplicate' })).toBeVisible();
     await expect(table.getByText('Alpha')).toBeVisible();
     await expect(table.getByText('Küçük Prens, "Ciltli"')).toBeVisible();
 
@@ -105,5 +166,33 @@ test.describe('Duplicate audit', () => {
     await expect(main).not.toContainText('http');
     await expect(main).not.toContainText('uploader');
     await expect(main).not.toContainText('email');
+  });
+
+  test('admin marks a duplicate and undoes it through the real page', async ({ page }) => {
+    page.on('dialog', (dialog) => dialog.accept());
+
+    await page.goto('/admin/duplicate-audit');
+    await page.getByRole('button', { name: 'Run Audit' }).click();
+
+    // The canonical defaults to the first unmarked book and cannot be a
+    // selected duplicate itself.
+    await expect(page.getByRole('radio', { name: 'Set Alpha as canonical' })).toBeChecked();
+    await expect(page.getByRole('checkbox', { name: 'Select Alpha as duplicate' })).toBeDisabled();
+
+    await page.getByRole('checkbox', { name: 'Select Küçük Prens, "Ciltli" as duplicate' }).check();
+    await page.getByRole('button', { name: 'Mark duplicates' }).click();
+
+    expect(markPayloads).toEqual([{ canonicalId: 'b1', duplicateIds: ['b2'] }]);
+
+    // The refetched report marks b2 under b1 with an undo action.
+    await expect(page.getByTestId('marked-b2')).toContainText('Duplicate of b1');
+    await expect(
+      page.getByRole('button', { name: 'Undo mark for Küçük Prens, "Ciltli"' })
+    ).toBeVisible();
+
+    await page.getByRole('button', { name: 'Undo mark for Küçük Prens, "Ciltli"' }).click();
+
+    expect(unmarkPayloads).toEqual([{ duplicateIds: ['b2'] }]);
+    await expect(page.getByTestId('marked-b2')).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## Summary

Adds a reversible **soft-hide** mechanism for duplicate books in the admin duplicate audit, replacing the read-only report with actionable controls. An admin picks a canonical book and marks duplicates; marked books disappear from every public surface while the data itself is never deleted.

- **Canonical selection** – each audit group defaults to the first unmarked book as canonical; admins can switch it via radio buttons.
- **Mark** – selects one or more duplicates (max 50 per batch) and soft-hides them under the canonical after a confirmation dialog.
- **Undo** – a per-row "Undo" action restores any hidden book to public visibility (reversible by design).
- **Public filters** – hidden duplicates are excluded from all-books, recently-added, search (with search-cache invalidation on mark/unmark), book detail, OG preview, and the sitemap.
- **Delete + ratings guards** – a canonical with hidden duplicates cannot be deleted until they are unmarked; ratings summary/reviews/rate-writes return 404 for hidden duplicates.
- **Integrity guards** – self-mark, chains/cycles, repointing to a different canonical, and missing ids are rejected; an in-process mutation queue serializes mark/unmark writes; no hard delete ever runs (mark/unmark only set `duplicateOf`).

## Database

`duplicateOf` added to the `Books` model as an **optional nullable** `ObjectId` referencing the canonical book. **No index, no migration, no backfill** – a deliberate, operator-approved minimal plan.

## Verification

- Backend: 84 Jest tests pass (`backend/`)
- Client: 71 Vitest tests pass (`client/`)
- E2E: 9 Playwright tests pass (`client/`)
- Backend build (`tsc`) and client build (`vite build`) pass
- Biome `check` on staged files: no errors

## Notes

- No dependency, lockfile, cloudinary, or migration changes.
- Existing tests kept intact and passing.

Closes #379